### PR TITLE
Generic classes, type parameters, events, multi-index indexers, and a line-break fix

### DIFF
--- a/CSharpAuthor.Tests/ClassDefinitionTests/EventDefinitionTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/EventDefinitionTests.cs
@@ -1,0 +1,60 @@
+using System;
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+public class EventDefinitionTests
+{
+    [Fact]
+    public void FieldLikeEvent()
+    {
+        var classDefinition = new ClassDefinition("Publisher");
+        classDefinition.AddEvent(typeof(EventHandler), "Changed");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(FieldLikeOutput, context.Output());
+    }
+
+    private const string FieldLikeOutput =
+        @"public class Publisher
+{
+
+    public event EventHandler Changed;
+}
+";
+
+    [Fact]
+    public void EventWithAccessors()
+    {
+        var classDefinition = new ClassDefinition("Publisher");
+
+        var eventDefinition = classDefinition.AddEvent(typeof(EventHandler), "Changed");
+        eventDefinition.Add.AddIndentedStatement("_inner.Changed += value");
+        eventDefinition.Remove.AddIndentedStatement("_inner.Changed -= value");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(AccessorsOutput, context.Output());
+    }
+
+    private const string AccessorsOutput =
+        @"public class Publisher
+{
+
+    public event EventHandler Changed
+    {
+        add
+        {
+            _inner.Changed += value;
+        }
+        remove
+        {
+            _inner.Changed -= value;
+        }
+    }
+}
+";
+}

--- a/CSharpAuthor.Tests/ClassDefinitionTests/GenericClassDefinitionTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/GenericClassDefinitionTests.cs
@@ -1,0 +1,170 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+public class GenericClassDefinitionTests
+{
+    [Fact]
+    public void GenericClass()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(GenericClassOutput, context.Output());
+    }
+
+    private const string GenericClassOutput =
+        @"public class Box<T>
+{
+}
+";
+
+    [Fact]
+    public void GenericClassWithSeveralParameters()
+    {
+        var classDefinition = new ClassDefinition("Pair");
+        classDefinition.AddGenericParameter("TKey");
+        classDefinition.AddGenericParameter("TValue");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(SeveralParametersOutput, context.Output());
+    }
+
+    private const string SeveralParametersOutput =
+        @"public class Pair<TKey, TValue>
+{
+}
+";
+
+    /// <summary>
+    /// A generic base type closed over the declaring type's own parameter, which is what a wrapper
+    /// deriving from a generic base needs.
+    /// </summary>
+    [Fact]
+    public void GenericClassWithGenericBaseType()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddBaseType(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "Ns",
+                "Container",
+                new ITypeDefinition[] { new TypeParameterDefinition("T") }));
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(GenericBaseTypeOutput, context.Output());
+    }
+
+    private const string GenericBaseTypeOutput =
+        @"public class Box<T> : Container<T>
+{
+}
+";
+
+    [Fact]
+    public void GenericClassWithConstraints()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddBaseType(TypeDefinition.Get("Ns", "Container"));
+        classDefinition.WhereStatement =
+            new CodeOutputComponent(" where T : class, new()") { Indented = false };
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(ConstraintsOutput, context.Output());
+    }
+
+    private const string ConstraintsOutput =
+        @"public class Box<T> : Container where T : class, new()
+{
+}
+";
+
+    /// <summary>
+    /// The constructor takes the name without the type parameters. Writing them would produce
+    /// <c>public Box&lt;T&gt;()</c>, which does not compile.
+    /// </summary>
+    [Fact]
+    public void GenericClassConstructorOmitsTheTypeParameters()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.AddParameter(new TypeParameterDefinition("T"), "value");
+        constructor.AddIndentedStatement("_value = value");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(ConstructorOutput, context.Output());
+    }
+
+    private const string ConstructorOutput =
+        @"public class Box<T>
+{
+
+    public Box(T value)
+    {
+        _value = value;
+    }
+}
+";
+
+    /// <summary>
+    /// The shape a generated wrapper needs: a nested generic class closing a generic base over the
+    /// enclosing method's type parameter, repeating its constraints so the call it forwards
+    /// satisfies them.
+    /// </summary>
+    [Fact]
+    public void NestedGenericClassWithConstraints()
+    {
+        var wrapper = new ClassDefinition("Wrapper");
+
+        var state = wrapper.AddClass("State");
+        state.Modifiers |= ComponentModifier.Private | ComponentModifier.Sealed;
+        state.AddGenericParameter("T");
+        state.AddBaseType(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "Ns",
+                "InvocationState",
+                new ITypeDefinition[] { new TypeParameterDefinition("T") }));
+        state.WhereStatement = new CodeOutputComponent(" where T : class") { Indented = false };
+
+        var invoke = state.AddMethod("Invoke");
+        invoke.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        invoke.SetReturnType(new TypeParameterDefinition("T"));
+        invoke.Return("_inner.Pick<T>(_arg0)");
+
+        var context = new OutputContext();
+        wrapper.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(NestedGenericOutput, context.Output());
+    }
+
+    private const string NestedGenericOutput =
+        @"public class Wrapper
+{
+
+    private sealed class State<T> : InvocationState<T> where T : class
+    {
+
+        public override T Invoke()
+        {
+            return _inner.Pick<T>(_arg0);
+        }
+    }
+}
+";
+}

--- a/CSharpAuthor.Tests/MethodTests/MethodInvokeTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/MethodInvokeTests.cs
@@ -27,8 +27,8 @@ public class MethodInvokeTests
 {
     var helloVar = ""Hello"";
     helloVar.ToString(
-        1, 
-        2, 
+        1,
+        2,
         3
     );
 }

--- a/CSharpAuthor.Tests/PropertyDefinitionTests/IndexerPropertyTests.cs
+++ b/CSharpAuthor.Tests/PropertyDefinitionTests/IndexerPropertyTests.cs
@@ -1,0 +1,108 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.PropertyDefinitionTests;
+
+public class IndexerPropertyTests
+{
+    [Fact]
+    public void SingleIndexIndexer()
+    {
+        var classDefinition = new ClassDefinition("Row");
+
+        var property = classDefinition.AddProperty(typeof(string), "this");
+        property.IndexType = TypeDefinition.Get(typeof(int));
+        property.Get.AddIndentedStatement("return _values[index]");
+        property.Set!.AddIndentedStatement("_values[index] = value");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(SingleIndexOutput, context.Output());
+    }
+
+    private const string SingleIndexOutput =
+        @"public class Row
+{
+
+    public string this[int index]
+    {
+        get
+        {
+            return _values[index];
+        }
+        set
+        {
+            _values[index] = value;
+        }
+    }
+}
+";
+
+    [Fact]
+    public void IndexerWithSeveralIndices()
+    {
+        var classDefinition = new ClassDefinition("Grid");
+
+        var property = classDefinition.AddProperty(typeof(int), "this");
+        property.AddIndexParameter(TypeDefinition.Get(typeof(int)), "row");
+        property.AddIndexParameter(TypeDefinition.Get(typeof(int)), "column");
+        property.Get.AddIndentedStatement("return _cells[row, column]");
+        property.Set!.AddIndentedStatement("_cells[row, column] = value");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(SeveralIndicesOutput, context.Output());
+    }
+
+    private const string SeveralIndicesOutput =
+        @"public class Grid
+{
+
+    public int this[int row, int column]
+    {
+        get
+        {
+            return _cells[row, column];
+        }
+        set
+        {
+            _cells[row, column] = value;
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// An indexer has no auto-property form, so a read-only one still writes its accessor out.
+    /// </summary>
+    [Fact]
+    public void ReadOnlyIndexer()
+    {
+        var classDefinition = new ClassDefinition("Row");
+
+        var property = classDefinition.AddProperty(typeof(string), "this");
+        property.AddIndexParameter(TypeDefinition.Get(typeof(int)), "index");
+        property.Set = null;
+        property.Get.AddIndentedStatement("return _values[index]");
+
+        var context = new OutputContext();
+        classDefinition.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(ReadOnlyOutput, context.Output());
+    }
+
+    private const string ReadOnlyOutput =
+        @"public class Row
+{
+
+    public string this[int index]
+    {
+        get
+        {
+            return _values[index];
+        }
+    }
+}
+";
+}

--- a/CSharpAuthor.Tests/TypeDefinitionTests/TypeParameterDefinitionTests.cs
+++ b/CSharpAuthor.Tests/TypeDefinitionTests/TypeParameterDefinitionTests.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using Xunit;
+
+namespace CSharpAuthor.Tests.TypeDefinitionTests;
+
+public class TypeParameterDefinitionTests
+{
+    /// <summary>
+    /// A type parameter names nothing outside its declaration, so it is written as itself even
+    /// where a real type would be qualified.
+    /// </summary>
+    [Theory]
+    [InlineData(TypeOutputMode.ShortName)]
+    [InlineData(TypeOutputMode.FullName)]
+    [InlineData(TypeOutputMode.Global)]
+    public void WrittenUnqualifiedInEveryMode(TypeOutputMode mode)
+    {
+        var builder = new StringBuilder();
+
+        new TypeParameterDefinition("T").WriteTypeName(builder, mode);
+
+        Assert.Equal("T", builder.ToString());
+    }
+
+    [Fact]
+    public void NullableAndArray()
+    {
+        var builder = new StringBuilder();
+
+        new TypeParameterDefinition("T").MakeNullable().WriteTypeName(builder);
+
+        Assert.Equal("T?", builder.ToString());
+
+        builder.Clear();
+
+        new TypeParameterDefinition("T").MakeArray().WriteTypeName(builder);
+
+        Assert.Equal("T[]", builder.ToString());
+    }
+
+    /// <summary>
+    /// Value equality matters to a source generator: it caches on models holding these, and
+    /// reference equality would miss that cache on every edit.
+    /// </summary>
+    [Fact]
+    public void EqualByValue()
+    {
+        Assert.Equal(new TypeParameterDefinition("T"), new TypeParameterDefinition("T"));
+        Assert.Equal(new TypeParameterDefinition("T").GetHashCode(), new TypeParameterDefinition("T").GetHashCode());
+
+        Assert.NotEqual(new TypeParameterDefinition("T"), new TypeParameterDefinition("U"));
+        Assert.NotEqual(new TypeParameterDefinition("T"), (ITypeDefinition)TypeDefinition.Get("Ns", "T"));
+    }
+
+    [Fact]
+    public void ClosesAGenericType()
+    {
+        var builder = new StringBuilder();
+
+        new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "Ns",
+                "Container",
+                new ITypeDefinition[] { new TypeParameterDefinition("T") })
+            .WriteTypeName(builder, TypeOutputMode.Global);
+
+        Assert.Equal("global::Ns.Container<T>", builder.ToString());
+    }
+}

--- a/CSharpAuthor/ClassDefinition.cs
+++ b/CSharpAuthor/ClassDefinition.cs
@@ -22,6 +22,8 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
     private readonly List<PropertyDefinition> _properties = new();
     private readonly List<ClassDefinition> _classes = new();
     private readonly List<IOutputComponent> _otherComponents = new();
+    private readonly List<ITypeDefinition> _genericParameters = new();
+    private readonly List<EventDefinition> _events = new();
 
     public ClassDefinition(string name)
     {
@@ -31,6 +33,31 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
     public string Name { get; }
 
     public ClassKeyword TypeKeyword { get; set; } = ClassKeyword.Class;
+
+    /// <summary>
+    /// The type parameters this type is declared with, written as Name&lt;T, U&gt;.
+    /// </summary>
+    public IReadOnlyList<ITypeDefinition> GenericParameters => _genericParameters;
+
+    /// <summary>
+    /// The constraint clause, written after the base types: <c>where T : class, new()</c>.
+    /// </summary>
+    public IOutputComponent? WhereStatement { get; set; }
+
+    public ClassDefinition AddGenericParameter(ITypeDefinition typeDefinition)
+    {
+        _genericParameters.Add(typeDefinition);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a type parameter by name, for the common case of an unbound one.
+    /// </summary>
+    public ClassDefinition AddGenericParameter(string name)
+    {
+        return AddGenericParameter(new TypeParameterDefinition(name));
+    }
 
     public int FieldCount => _fields.Count;
 
@@ -51,6 +78,9 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
                 break;
             case PropertyDefinition propertyDefinition:
                 _properties.Add(propertyDefinition);
+                break;
+            case EventDefinition eventDefinition:
+                _events.Add(eventDefinition);
                 break;
             case FieldDefinition fieldDefinition:
                 _fields.Add(fieldDefinition);
@@ -90,6 +120,14 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
             foreach (var property in _properties)
             {
                 yield return property;
+            }
+        }
+
+        if (_events.Count > 0)
+        {
+            foreach (var eventDefinition in _events)
+            {
+                yield return eventDefinition;
             }
         }
 
@@ -141,6 +179,20 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
     public PropertyDefinition AddProperty(Type type, string fieldName)
     {
         return AddProperty(TypeDefinition.Get(type), fieldName);
+    }
+
+    public EventDefinition AddEvent(Type handlerType, string name)
+    {
+        return AddEvent(TypeDefinition.Get(handlerType), name);
+    }
+
+    public EventDefinition AddEvent(ITypeDefinition handlerType, string name)
+    {
+        var eventDefinition = new EventDefinition(handlerType, name);
+
+        _events.Add(eventDefinition);
+
+        return eventDefinition;
     }
 
     public PropertyDefinition AddProperty(ITypeDefinition type, string fieldName)
@@ -239,25 +291,37 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
             outputContext,
             _properties,
             method => method.Modifiers.HasFlag(ComponentModifier.Public));
-        
+
         WriteMemberComponents(
-            componentAction, 
-            outputContext, 
+            componentAction,
+            outputContext,
+            _events,
+            e => e.Modifiers.HasFlag(ComponentModifier.Public));
+
+        WriteMemberComponents(
+            componentAction,
+            outputContext,
             _methods,
             m => m.Modifiers.HasFlag(ComponentModifier.Public));
-        
+
         WriteMemberComponents(
             componentAction,
             outputContext,
             _properties,
             method => !method.Modifiers.HasFlag(ComponentModifier.Public));
-        
+
         WriteMemberComponents(
-            componentAction, 
-            outputContext, 
+            componentAction,
+            outputContext,
+            _events,
+            e => !e.Modifiers.HasFlag(ComponentModifier.Public));
+
+        WriteMemberComponents(
+            componentAction,
+            outputContext,
             _methods,
             m => !m.Modifiers.HasFlag(ComponentModifier.Public));
-        
+
         foreach (var classDefinition in _classes)
         {
             outputContext.WriteLine();
@@ -342,12 +406,24 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
 
         outputContext.Write(Name);
 
+        if (_genericParameters.Count > 0)
+        {
+            outputContext.Write("<");
+
+            _genericParameters.OutputCommaSeparatedList(outputContext);
+
+            outputContext.Write(">");
+        }
+
         if (_baseTypes.Count > 0)
         {
             outputContext.Write(" : ");
 
             _baseTypes.OutputCommaSeparatedList(outputContext);
         }
+
+        // After the base types, which is where C# puts it.
+        WhereStatement?.WriteOutput(outputContext);
 
         outputContext.WriteLine();
     }

--- a/CSharpAuthor/EventDefinition.cs
+++ b/CSharpAuthor/EventDefinition.cs
@@ -1,0 +1,103 @@
+using System;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// An event, written either as a field-like declaration or with add and remove accessors.
+/// </summary>
+/// <remarks>
+/// <c>public event EventHandler Changed;</c> when neither accessor has a body, and
+/// <c>public event EventHandler Changed { add { } remove { } }</c> when either does. A type
+/// implementing an interface that declares an event has to declare one too, so a generated wrapper
+/// cannot be written without this.
+/// </remarks>
+public class EventDefinition : BaseOutputComponent, INamedComponent
+{
+    public EventDefinition(ITypeDefinition handlerType, string name)
+    {
+        HandlerType = handlerType;
+        Name = name;
+
+        Add = new PropertyMethodDefinition();
+        Remove = new PropertyMethodDefinition();
+    }
+
+    public string Name { get; }
+
+    /// <summary>
+    /// The delegate type the event is declared with.
+    /// </summary>
+    public ITypeDefinition HandlerType { get; }
+
+    public PropertyMethodDefinition Add { get; }
+
+    public PropertyMethodDefinition Remove { get; }
+
+    protected override void WriteComponentOutput(IOutputContext outputContext)
+    {
+        outputContext.AddImportNamespace(HandlerType);
+
+        var accessModifier = GetAccessModifier(KeyWords.Public);
+
+        outputContext.WriteIndent();
+
+        if (!string.IsNullOrEmpty(accessModifier))
+        {
+            outputContext.Write(accessModifier);
+            outputContext.WriteSpace();
+        }
+
+        if ((Modifiers & ComponentModifier.Static) == ComponentModifier.Static)
+        {
+            outputContext.Write(KeyWords.Static);
+            outputContext.WriteSpace();
+        }
+        else if ((Modifiers & ComponentModifier.Virtual) == ComponentModifier.Virtual)
+        {
+            outputContext.Write(KeyWords.Virtual);
+            outputContext.WriteSpace();
+        }
+        else if ((Modifiers & ComponentModifier.Override) == ComponentModifier.Override)
+        {
+            outputContext.Write(KeyWords.Override);
+            outputContext.WriteSpace();
+        }
+
+        outputContext.Write("event ");
+        outputContext.Write(HandlerType);
+        outputContext.WriteSpace();
+        outputContext.Write(Name);
+
+        // Without a body on either accessor this is a field-like event, which is the shape almost
+        // every event is declared in.
+        if (Add.StatementCount == 0 && Remove.StatementCount == 0)
+        {
+            outputContext.WriteLine(";");
+
+            return;
+        }
+
+        outputContext.WriteLine();
+        outputContext.OpenScope();
+
+        outputContext.WriteIndent("add");
+        Add.WriteOutput(outputContext);
+
+        outputContext.WriteIndent("remove");
+        Remove.WriteOutput(outputContext);
+
+        outputContext.CloseScope();
+    }
+
+    protected override void WriteComment(IOutputContext outputContext)
+    {
+        if (string.IsNullOrWhiteSpace(Comment))
+        {
+            return;
+        }
+
+        outputContext.WriteIndentedLine("/// <summary>");
+        outputContext.WriteIndentedLine($"/// {Comment}");
+        outputContext.WriteIndentedLine("/// </summary>");
+    }
+}

--- a/CSharpAuthor/IEnumerableExtensions.cs
+++ b/CSharpAuthor/IEnumerableExtensions.cs
@@ -24,48 +24,47 @@ public static class IEnumerableExtensions
 
     public static void OutputSeparatedList<T>(this IEnumerable<T> components, IOutputContext context, Action<IOutputContext, T> writeAction, string separator, bool newLineBeforeItems = false)
     {
-        var writeSeparator = false;
+        IReadOnlyList<T> list = components as IReadOnlyList<T> ?? components.ToList();
 
-        if (newLineBeforeItems)
+        // A list of one stays on the line it was opened on. Indenting for a break that never
+        // happens leaves the closing bracket stranded mid-line, which is what a single argument
+        // wrapping a broken one used to produce: Intercept(new Context(\n ... \n    )    );
+        var breakLines = newLineBeforeItems && list.Count > 1;
+
+        if (breakLines)
         {
             context.IncrementIndent();
         }
-        
-        IReadOnlyList<T>? list = components as IReadOnlyList<T> ?? components.ToList();
+
+        var writeSeparator = false;
 
         foreach (var tValue in list)
         {
             if (writeSeparator)
             {
-                context.Write(separator);
+                // The line break already separates the items, so the separator does not also pad
+                // the end of the line it terminates.
+                context.Write(breakLines ? separator.TrimEnd() : separator);
             }
             else
             {
                 writeSeparator = true;
             }
-            
-            if (newLineBeforeItems && list.Count > 1)
+
+            if (breakLines)
             {
                 context.WriteLine();
                 context.WriteIndent();
             }
-            
+
             writeAction(context, tValue);
         }
-        
-        if (newLineBeforeItems)
-        {
-            if (list.Count > 1)
-            {
-                context.WriteLine();
-            }
-            
-            context.DecrementIndent();
 
-            if (list.Count > 0)
-            {
-                context.WriteIndent();
-            }
+        if (breakLines)
+        {
+            context.WriteLine();
+            context.DecrementIndent();
+            context.WriteIndent();
         }
     }
 }

--- a/CSharpAuthor/PropertyDefinition.cs
+++ b/CSharpAuthor/PropertyDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace CSharpAuthor;
+﻿using System.Collections.Generic;
+
+namespace CSharpAuthor;
 
 public class PropertyDefinition : BaseOutputComponent, INamedComponent
 {
@@ -19,9 +21,31 @@ public class PropertyDefinition : BaseOutputComponent, INamedComponent
 
     public PropertyMethodDefinition? Set { get; set; }
 
+    /// <summary>
+    /// The type of a single index, for the common <c>this[int index]</c> shape. Ignored when
+    /// <see cref="IndexParameters"/> has entries.
+    /// </summary>
     public ITypeDefinition? IndexType { get; set; }
 
+    /// <summary>
+    /// The name of the single index declared through <see cref="IndexType"/>.
+    /// </summary>
     public string IndexName { get; set; } = "index";
+
+    /// <summary>
+    /// Indices for an indexer that takes more than one, such as <c>this[int row, int column]</c>.
+    /// Takes precedence over <see cref="IndexType"/>.
+    /// </summary>
+    public List<ParameterDefinition> IndexParameters { get; } = new();
+
+    public PropertyDefinition AddIndexParameter(ITypeDefinition type, string name)
+    {
+        IndexParameters.Add(new ParameterDefinition(type, name));
+
+        return this;
+    }
+
+    private bool IsIndexer => IndexParameters.Count > 0 || IndexType != null;
 
     public InstanceDefinition Instance => new(Name);
     
@@ -34,7 +58,23 @@ public class PropertyDefinition : BaseOutputComponent, INamedComponent
         outputContext.Write(Type);
         outputContext.Write($" {Name}");
 
-        if (IndexType != null)
+        if (IndexParameters.Count > 0)
+        {
+            outputContext.Write("[");
+
+            for (var i = 0; i < IndexParameters.Count; i++)
+            {
+                if (i > 0)
+                {
+                    outputContext.Write(", ");
+                }
+
+                IndexParameters[i].WriteWithSignature(outputContext);
+            }
+
+            outputContext.Write("]");
+        }
+        else if (IndexType != null)
         {
             outputContext.Write("[");
             outputContext.Write(IndexType);
@@ -43,7 +83,9 @@ public class PropertyDefinition : BaseOutputComponent, INamedComponent
             outputContext.Write("]");
         }
 
-        if (Set == null && IndexType == null)
+        // An indexer has no auto-property or expression-bodied form to fall back to, so it always
+        // writes its accessors out in full.
+        if (Set == null && !IsIndexer)
         {
             if (Get.StatementCount == 0)
             {
@@ -57,7 +99,8 @@ public class PropertyDefinition : BaseOutputComponent, INamedComponent
                 return;
             }
         }
-        else if (Get.StatementCount == 0 &&
+        else if (!IsIndexer &&
+                 Get.StatementCount == 0 &&
                  Set is { StatementCount: 0 })
         {
             if (Set.IsInit)

--- a/CSharpAuthor/TypeParameterDefinition.cs
+++ b/CSharpAuthor/TypeParameterDefinition.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// A generic type parameter, such as the T in <c>class Box&lt;T&gt;</c> or <c>T Get&lt;T&gt;()</c>.
+/// </summary>
+/// <remarks>
+/// A type parameter names nothing outside the declaration it belongs to: it has no namespace, and
+/// qualifying it the way a real type is qualified would render it as the type that declared it.
+/// It is written as itself in every output mode.
+/// </remarks>
+public class TypeParameterDefinition : ITypeDefinition
+{
+    public TypeParameterDefinition(string name, bool isNullable = false, bool isArray = false)
+    {
+        Name = name;
+        IsNullable = isNullable;
+        IsArray = isArray;
+    }
+
+    public string Name { get; }
+
+    public string Namespace => "";
+
+    public TypeDefinitionEnum TypeDefinitionEnum => TypeDefinitionEnum.ClassDefinition;
+
+    public bool IsNullable { get; }
+
+    public bool IsArray { get; }
+
+    public IEnumerable<string> KnownNamespaces => Enumerable.Empty<string>();
+
+    public IReadOnlyList<ITypeDefinition> TypeArguments => Array.Empty<ITypeDefinition>();
+
+    public void WriteTypeName(StringBuilder builder, TypeOutputMode typeOutputMode = TypeOutputMode.ShortName)
+    {
+        builder.Append(Name);
+
+        if (IsArray)
+        {
+            builder.Append("[]");
+        }
+
+        if (IsNullable)
+        {
+            builder.Append("?");
+        }
+    }
+
+    public ITypeDefinition MakeNullable(bool nullable = true)
+    {
+        return new TypeParameterDefinition(Name, nullable, IsArray);
+    }
+
+    public ITypeDefinition MakeArray()
+    {
+        return new TypeParameterDefinition(Name, IsNullable, true);
+    }
+
+    public int CompareTo(ITypeDefinition other)
+    {
+        if (other is not TypeParameterDefinition typeParameter)
+        {
+            return -1;
+        }
+
+        var nameCompare = string.Compare(Name, typeParameter.Name, StringComparison.Ordinal);
+
+        if (nameCompare != 0)
+        {
+            return nameCompare;
+        }
+
+        if (IsArray != typeParameter.IsArray)
+        {
+            return IsArray ? 1 : -1;
+        }
+
+        if (IsNullable != typeParameter.IsNullable)
+        {
+            return IsNullable ? 1 : -1;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Value equality, so a model holding one compares equal across runs. A source generator caches
+    /// on its models, and reference equality would miss that cache on every edit.
+    /// </summary>
+    public override bool Equals(object obj)
+    {
+        return obj is TypeParameterDefinition other && CompareTo(other) == 0;
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Name.GetHashCode();
+
+            hash = hash * 31 + IsNullable.GetHashCode();
+            hash = hash * 31 + IsArray.GetHashCode();
+
+            return hash;
+        }
+    }
+
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+
+        WriteTypeName(builder);
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
Found while generating interception wrappers with CSharpAuthor in DependencyModules. Each item below is something that had to be worked around outside the library, or output that was wrong.

## Bug: line breaking on single-argument and nested invocations

`OutputSeparatedList` wrote its closing indent whenever the list was non-empty, including when it never broke the list onto separate lines. A single argument wrapping a broken one stranded the closing bracket mid-line:

```csharp
return _interceptor.Intercept(new Context(
        this, 
        0
    )                        );
```

It also wrote the `", "` separator *before* the line break, leaving trailing whitespace at the end of every broken line (visible above after `this,`).

Now:

```csharp
return _interceptor.Intercept(new Context(
    this,
    0
));
```

A list of one stays on the line it was opened on, and the separator is trimmed when a line break already separates the items. `MethodInvokeTests` asserted the trailing whitespace, so its expectation is updated — that is the only behavioural change to existing output.

## Generic classes

`ClassDefinition` could not declare type parameters or constraints; only `MethodDefinition` could. A nested state class deriving from a generic base and repeating its member's constraints was inexpressible, so downstream the parameters got smuggled through the class *name* and the constraint clause was attached to the *base type* via a custom `ITypeDefinition`.

```csharp
var state = wrapper.AddClass("State");
state.AddGenericParameter("T");
state.AddBaseType(new GenericTypeDefinition(..., "InvocationState", new[] { new TypeParameterDefinition("T") }));
state.WhereStatement = new CodeOutputComponent(" where T : class") { Indented = false };
```

```csharp
private sealed class State<T> : InvocationState<T> where T : class
```

`GenericParameters` and `WhereStatement` mirror `MethodDefinition`'s API. `AddConstructor` keeps using the bare `Name`, so a generic class gets `public Box(...)` rather than `public Box<T>(...)` — that was a latent bug that only becomes reachable now.

## TypeParameterDefinition

Nothing expressed a bare `T` as an `ITypeDefinition`, so it had to be reimplemented downstream. Qualifying a type parameter the way a real type is qualified renders it as the type that *declared* it (`IWork.T`), which names nothing.

It carries value equality, which a source generator needs: its models are the incremental cache key, and reference equality misses that cache on every keystroke. The downstream copy lacked this and had exactly that problem.

## Events

No representation at all, so a type implementing an interface that declares an event could not be generated. `EventDefinition` writes the field-like form when neither accessor has a body and the add/remove form when either does.

```csharp
public event EventHandler Changed
{
    add
    {
        _inner.Changed += value;
    }
    remove
    {
        _inner.Changed -= value;
    }
}
```

## Multi-index indexers

`PropertyDefinition` wrote a single `IndexType`/`IndexName`, so `this[int row, int column]` was out of reach. `IndexParameters` takes any number; `IndexType`/`IndexName` still work unchanged for the single-index case. An indexer also no longer falls through to the auto-property form (`{ get; set; }`), which is not valid for one.

## Notes

- 69 tests pass, up from 52. New coverage for each item above, including the nested-generic-with-constraints shape that motivated this.
- Version left alone — `appveyor.yml` drives that separately, so bumping it here would collide with however you sequence releases.
- Not included, but adjacent: `ParameterDefinition` has `IsOut` and `This` but no `ref`, `in`, or `params`. `params` in particular gets silently dropped when reproducing an interface signature. Happy to add it if you want it in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgLfDy82CnQZiuU5j8byu9