### PR TITLE
Add ref, in, ref readonly and params to ParameterDefinition

### DIFF
--- a/CSharpAuthor.Tests/MethodTests/ParameterModifierTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/ParameterModifierTests.cs
@@ -1,0 +1,174 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.MethodTests;
+
+public class ParameterModifierTests
+{
+    [Theory]
+    [InlineData(ParameterModifier.None, "public void Test(int value)")]
+    [InlineData(ParameterModifier.Ref, "public void Test(ref int value)")]
+    [InlineData(ParameterModifier.Out, "public void Test(out int value)")]
+    [InlineData(ParameterModifier.In, "public void Test(in int value)")]
+    [InlineData(ParameterModifier.RefReadOnly, "public void Test(ref readonly int value)")]
+    public void ModifierIsWritten(ParameterModifier modifier, string expected)
+    {
+        var method = new MethodDefinition("Test");
+        method.Modifiers |= ComponentModifier.Public;
+        method.AddParameter(typeof(int), "value").Modifier = modifier;
+
+        var context = new OutputContext();
+        method.WriteOutput(context);
+
+        Assert.StartsWith(expected, context.Output());
+    }
+
+    [Fact]
+    public void ParamsIsWritten()
+    {
+        var method = new MethodDefinition("Test");
+        method.Modifiers |= ComponentModifier.Public;
+        method.AddParameter(TypeDefinition.Get(typeof(int)).MakeArray(), "values").IsParams = true;
+
+        var context = new OutputContext();
+        method.WriteOutput(context);
+
+        Assert.StartsWith("public void Test(params int[] values)", context.Output());
+    }
+
+    /// <summary>
+    /// An extension method on a struct receiver takes both, which the previous either-or handling
+    /// could not express.
+    /// </summary>
+    [Fact]
+    public void ThisCombinesWithAModifier()
+    {
+        var method = new MethodDefinition("Test");
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
+
+        var parameter = method.AddParameter(TypeDefinition.Get("Ns", "Point"), "point");
+        parameter.This = true;
+        parameter.Modifier = ParameterModifier.Ref;
+
+        var context = new OutputContext();
+        method.WriteOutput(context);
+
+        Assert.StartsWith("public static void Test(this ref Point point)", context.Output());
+    }
+
+    /// <summary>
+    /// IsOut predates the modifier and stays the shorthand for it.
+    /// </summary>
+    [Fact]
+    public void IsOutSetsAndReadsTheModifier()
+    {
+        var parameter = new ParameterDefinition(TypeDefinition.Get(typeof(int)), "value");
+
+        Assert.False(parameter.IsOut);
+
+        parameter.IsOut = true;
+
+        Assert.Equal(ParameterModifier.Out, parameter.Modifier);
+        Assert.True(parameter.IsOut);
+
+        parameter.IsOut = false;
+
+        Assert.Equal(ParameterModifier.None, parameter.Modifier);
+
+        parameter.Modifier = ParameterModifier.Out;
+
+        Assert.True(parameter.IsOut);
+
+        parameter.Modifier = ParameterModifier.Ref;
+
+        Assert.False(parameter.IsOut);
+    }
+
+    [Fact]
+    public void ParametersKeepTheirDefaults()
+    {
+        var method = new MethodDefinition("Test");
+        method.Modifiers |= ComponentModifier.Public;
+
+        var parameter = method.AddParameter(typeof(int), "value");
+        parameter.Modifier = ParameterModifier.In;
+        parameter.DefaultValue = new CodeOutputComponent("5") { Indented = false };
+
+        var context = new OutputContext();
+        method.WriteOutput(context);
+
+        Assert.StartsWith("public void Test(in int value = 5)", context.Output());
+    }
+
+    /// <summary>
+    /// Forwarding a call repeats ref and out, or it does not compile. in and ref readonly are
+    /// optional at a call site and are left off.
+    /// </summary>
+    [Theory]
+    [InlineData(ParameterModifier.None, "value")]
+    [InlineData(ParameterModifier.Ref, "ref value")]
+    [InlineData(ParameterModifier.Out, "out value")]
+    [InlineData(ParameterModifier.In, "value")]
+    [InlineData(ParameterModifier.RefReadOnly, "value")]
+    public void WrittenAsAnArgument(ParameterModifier modifier, string expected)
+    {
+        var parameter = new ParameterDefinition(TypeDefinition.Get(typeof(int)), "value")
+        {
+            Modifier = modifier
+        };
+
+        var context = new OutputContext();
+        parameter.AsArgument().WriteOutput(context);
+
+        Assert.Equal(expected, context.Output());
+    }
+
+    /// <summary>
+    /// The whole point of the argument form: a wrapper forwarding to the method it wraps.
+    /// </summary>
+    [Fact]
+    public void ForwardingACallRepeatsTheModifiers()
+    {
+        var method = new MethodDefinition("TryGet");
+        method.Modifiers |= ComponentModifier.Public;
+        method.SetReturnType(typeof(bool));
+
+        var key = method.AddParameter(typeof(string), "key");
+        var value = method.AddParameter(typeof(int), "value");
+        value.Modifier = ParameterModifier.Out;
+
+        method.Return(
+            CodeOutputComponent.Get("_inner").Invoke("TryGet", key.AsArgument(), value.AsArgument()));
+
+        var context = new OutputContext();
+        method.WriteOutput(context);
+
+        AssertEqual.WithoutNewLine(ForwardingOutput, context.Output());
+    }
+
+    private const string ForwardingOutput =
+        @"public bool TryGet(string key, out int value)
+{
+    return _inner.TryGet(
+        key,
+        out value
+    );
+}
+";
+
+    /// <summary>
+    /// A parameter used as an ordinary value expression is still just its name.
+    /// </summary>
+    [Fact]
+    public void WrittenAsAValueIgnoresTheModifier()
+    {
+        var parameter = new ParameterDefinition(TypeDefinition.Get(typeof(int)), "value")
+        {
+            Modifier = ParameterModifier.Ref
+        };
+
+        var context = new OutputContext();
+        parameter.WriteOutput(context);
+
+        Assert.Equal("value", context.Output());
+    }
+}

--- a/CSharpAuthor/KeyWords.cs
+++ b/CSharpAuthor/KeyWords.cs
@@ -33,4 +33,14 @@ public static class KeyWords
     public static string Sealed => "sealed";
 
     public static string Record => "record";
+
+    public static string Ref => "ref";
+
+    public static string Out => "out";
+
+    public static string In => "in";
+
+    public static string Params => "params";
+
+    public static string This => "this";
 }

--- a/CSharpAuthor/ParameterDefinition.cs
+++ b/CSharpAuthor/ParameterDefinition.cs
@@ -1,4 +1,4 @@
-﻿namespace CSharpAuthor;
+namespace CSharpAuthor;
 
 public class ParameterDefinition : InstanceDefinition
 {
@@ -8,10 +8,36 @@ public class ParameterDefinition : InstanceDefinition
         TypeDefinition = typeDefinition;
     }
 
-    public bool IsOut { get; set; } = false;
+    /// <summary>
+    /// How the parameter is passed.
+    /// </summary>
+    public ParameterModifier Modifier { get; set; } = ParameterModifier.None;
 
+    /// <summary>
+    /// Whether the parameter is declared with <c>params</c>.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful on the last parameter, and only for a type the caller can spread into. It is
+    /// written as declared rather than validated here, matching how the rest of this library treats
+    /// what it is handed.
+    /// </remarks>
+    public bool IsParams { get; set; } = false;
+
+    /// <summary>
+    /// Assigned by the callee. Shorthand for <see cref="Modifier"/>.
+    /// </summary>
+    public bool IsOut
+    {
+        get => Modifier == ParameterModifier.Out;
+        set => Modifier = value ? ParameterModifier.Out : ParameterModifier.None;
+    }
+
+    /// <summary>
+    /// Whether this is the receiver of an extension method. Combines with <see cref="Modifier"/>,
+    /// since <c>this ref</c> and <c>this in</c> are both allowed on a struct receiver.
+    /// </summary>
     public bool This { get; set; } = false;
-    
+
     public ITypeDefinition TypeDefinition { get; }
 
     public IOutputComponent? DefaultValue { get; set; }
@@ -22,11 +48,22 @@ public class ParameterDefinition : InstanceDefinition
 
         if (This)
         {
-            outputContext.Write("this ");
+            outputContext.Write(KeyWords.This);
+            outputContext.WriteSpace();
         }
-        else if (IsOut)
+
+        var modifier = GetModifierKeyword();
+
+        if (modifier != null)
         {
-            outputContext.Write("out ");
+            outputContext.Write(modifier);
+            outputContext.WriteSpace();
+        }
+
+        if (IsParams)
+        {
+            outputContext.Write(KeyWords.Params);
+            outputContext.WriteSpace();
         }
 
         outputContext.Write(TypeDefinition);
@@ -38,6 +75,45 @@ public class ParameterDefinition : InstanceDefinition
             outputContext.Write(" = ");
             DefaultValue.WriteOutput(outputContext);
         }
+    }
+
+    /// <summary>
+    /// The parameter as an argument at a call site, carrying the modifier the callee declared, for
+    /// passing to <c>Invoke</c>, <c>New</c> and anything else that takes arguments.
+    /// </summary>
+    /// <remarks>
+    /// Forwarding a call has to repeat <c>ref</c> and <c>out</c>; leaving them off does not compile.
+    /// The parameter writes its bare name on its own, so one used as an ordinary value expression is
+    /// unaffected.
+    ///
+    /// <c>in</c> is optional at a call site and <c>ref readonly</c> only warns without it, so neither
+    /// is written: the argument reads the same either way.
+    /// </remarks>
+    public IOutputComponent AsArgument()
+    {
+        var modifier = Modifier switch
+        {
+            ParameterModifier.Ref => KeyWords.Ref,
+            ParameterModifier.Out => KeyWords.Out,
+            _ => null
+        };
+
+        return new CodeOutputComponent(modifier == null ? Name : modifier + " " + Name)
+        {
+            Indented = false
+        };
+    }
+
+    private string? GetModifierKeyword()
+    {
+        return Modifier switch
+        {
+            ParameterModifier.Ref => KeyWords.Ref,
+            ParameterModifier.Out => KeyWords.Out,
+            ParameterModifier.In => KeyWords.In,
+            ParameterModifier.RefReadOnly => KeyWords.Ref + " " + KeyWords.ReadOnly,
+            _ => null
+        };
     }
 
     protected override void WriteComponentOutput(IOutputContext outputContext)

--- a/CSharpAuthor/ParameterModifier.cs
+++ b/CSharpAuthor/ParameterModifier.cs
@@ -1,0 +1,26 @@
+namespace CSharpAuthor;
+
+/// <summary>
+/// How a parameter is passed.
+/// </summary>
+/// <remarks>
+/// The values line up with Roslyn's RefKind, so a parameter read off a symbol can be reproduced
+/// without the caller mapping between two vocabularies.
+/// </remarks>
+public enum ParameterModifier
+{
+    /// <summary>Passed by value.</summary>
+    None,
+
+    /// <summary>Passed by reference: <c>ref int value</c>.</summary>
+    Ref,
+
+    /// <summary>Assigned by the callee: <c>out int value</c>.</summary>
+    Out,
+
+    /// <summary>Passed by readonly reference: <c>in int value</c>.</summary>
+    In,
+
+    /// <summary>Passed by readonly reference, required at the call site: <c>ref readonly int value</c>.</summary>
+    RefReadOnly
+}


### PR DESCRIPTION
Follow-up to #6, which flagged this as the remaining gap.

A parameter could only be declared by value, `out`, or as an extension receiver. Reproducing a signature read off a symbol therefore lost `ref`, `in` and `params` — `params` **silently**, since dropping it still compiles and only changes what callers are allowed to write.

## ParameterModifier

```csharp
method.AddParameter(typeof(int), "value").Modifier = ParameterModifier.Ref;
```

```csharp
public void Test(ref int value)
```

The values line up with Roslyn's `RefKind` — `None`, `Ref`, `Out`, `In`, `RefReadOnly` — so a parameter read off a symbol maps across without the caller inventing a vocabulary in between.

`IsOut` stays as the shorthand it always was, reading and writing the modifier, so existing code is unaffected.

## params

```csharp
method.AddParameter(TypeDefinition.Get(typeof(int)).MakeArray(), "values").IsParams = true;
```

```csharp
public void Test(params int[] values)
```

## this combines with a modifier

`this ref` and `this in` are both allowed on a struct receiver. The previous `if (This) ... else if (IsOut)` could not express either.

```csharp
public static void Test(this ref Point point)
```

## AsArgument()

Forwarding a call has to repeat `ref` and `out` or it does not compile, which made `out` support only half usable:

```csharp
method.Return(CodeOutputComponent.Get("_inner").Invoke("TryGet", key.AsArgument(), value.AsArgument()));
```

```csharp
public bool TryGet(string key, out int value)
{
    return _inner.TryGet(
        key,
        out value
    );
}
```

It returns an `IOutputComponent` so it composes with `Invoke`, `New` and anything else taking arguments. `in` and `ref readonly` are optional at a call site and are left off — the argument reads the same either way. A parameter used as an ordinary value expression still writes its bare name, so nothing changes for existing callers passing one as an argument.

## Notes

- 85 tests pass, up from 69. No existing output changes.
- All parameter writing goes through `WriteWithSignature`, so interface methods, constructors and indexer indices pick this up too.
- Version left alone again, since `appveyor.yml` drives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgLfDy82CnQZiuU5j8byu9