### PR TITLE
Version 1.1.1008

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 1.1.1007
+  build_version: 1.1.1008
   Version: $(build_version)
 version: $(build_version)-{build}
 configuration: Release


### PR DESCRIPTION
Nested namespace reuse, primary constructors and the declaration-only form (#9).

## Changes generated output

`AddNamespace` now returns the nested namespace already there rather than appending a second one. A consumer that called it twice with the same name previously got two `namespace X { }` blocks in one file and now gets one — anything asserting on that text will see the diff.

Callers that want a distinct block can construct a `NamespaceDefinition` and pass it to `AddComponent`.

## Additive

`ConstructorDefinition.IsPrimary` and `ClassDefinition.TerminateWithSemicolon` are opt-in. Output is unchanged for anyone not setting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9nw6izRwGZ7BLa7RqwMZg