### PR TITLE
Write parameter attributes, and support attribute targets

### DIFF
--- a/CSharpAuthor.Tests/ClassDefinitionTests/ParameterAttributeTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/ParameterAttributeTests.cs
@@ -1,0 +1,109 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+/// <summary>
+/// Attributes on parameters, and the target that decides what they land on.
+/// </summary>
+/// <remarks>
+/// A parameter could always carry attributes - <c>AddAttribute</c> is on the base - but nothing
+/// wrote them. The target matters for a positional record, where the parameter and the property it
+/// declares are two things in one position: an attribute without <c>property:</c> stays on the
+/// parameter, where a source generator reading properties never sees it.
+/// </remarks>
+public class ParameterAttributeTests
+{
+    [Fact]
+    public void AParameterAttributeIsWrittenInline()
+    {
+        var classDefinition = new ClassDefinition("Service");
+        var method = classDefinition.AddMethod("Handle");
+
+        method.AddParameter(typeof(string), "value")
+            .AddAttribute(TypeDefinition.Get("Sample", "NotNullAttribute"));
+
+        Assert.Contains("public void Handle([NotNull] string value)", Write(classDefinition));
+    }
+
+    [Fact]
+    public void TheTargetIsWrittenWhenSet()
+    {
+        var classDefinition = new ClassDefinition("Pet") { TypeKeyword = ClassKeyword.Record };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+
+        var parameter = constructor.AddParameter(typeof(string), "Name");
+        parameter.AddAttribute(TypeDefinition.Get("Sample", "RequiredAttribute")).Target = "property";
+
+        Assert.Contains("public record Pet([property: Required] string Name)", Write(classDefinition));
+    }
+
+    [Fact]
+    public void SeveralAttributesEachGetTheirOwnBrackets()
+    {
+        var classDefinition = new ClassDefinition("Pet") { TypeKeyword = ClassKeyword.Record };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+
+        var parameter = constructor.AddParameter(typeof(string), "Name");
+        parameter.AddAttribute(TypeDefinition.Get("Sample", "RequiredAttribute")).Target = "property";
+        parameter.AddAttribute(TypeDefinition.Get("Sample", "StringLengthAttribute"),
+            new CodeOutputComponent("1") { Indented = false },
+            new CodeOutputComponent("100") { Indented = false }).Target = "property";
+
+        Assert.Contains(
+            "public record Pet([property: Required] [property: StringLength(1, 100)] string Name)",
+            Write(classDefinition));
+    }
+
+    [Fact]
+    public void ArgumentsAreWrittenOnAParameterAttribute()
+    {
+        var classDefinition = new ClassDefinition("Service");
+        var method = classDefinition.AddMethod("Handle");
+
+        method.AddParameter(typeof(string), "value")
+            .AddAttribute(TypeDefinition.Get("Sample", "RangeAttribute"),
+                new CodeOutputComponent("1") { Indented = false },
+                new CodeOutputComponent("10") { Indented = false });
+
+        Assert.Contains("Handle([Range(1, 10)] string value)", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// A target on an attribute written in its own right, rather than inline on a parameter.
+    /// </summary>
+    [Fact]
+    public void TheTargetIsWrittenOnAStandaloneAttributeToo()
+    {
+        var classDefinition = new ClassDefinition("Thing");
+
+        classDefinition.AddAttribute(TypeDefinition.Get("Sample", "SerializableAttribute")).Target = "type";
+
+        Assert.Contains("[type: Serializable]", Write(classDefinition));
+    }
+
+    [Fact]
+    public void AnAttributeWithNoTargetIsUnchanged()
+    {
+        var classDefinition = new ClassDefinition("Thing");
+
+        classDefinition.AddAttribute(TypeDefinition.Get("Sample", "SerializableAttribute"));
+
+        var output = Write(classDefinition);
+
+        Assert.Contains("[Serializable]", output);
+        Assert.DoesNotContain(":", output);
+    }
+
+    private static string Write(ClassDefinition classDefinition)
+    {
+        var context = new OutputContext();
+
+        classDefinition.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor/AttributeDefinition.cs
+++ b/CSharpAuthor/AttributeDefinition.cs
@@ -16,7 +16,41 @@ public class AttributeDefinition : BaseOutputComponent
 
     public IList<IOutputComponent>? Arguments { get; set; }
 
+    /// <summary>
+    /// The declaration the attribute applies to, written as <c>[target: Attr]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Needed wherever one syntactic position declares more than one thing and the attribute would
+    /// otherwise land on the wrong one. A positional record is the case that forces it: an attribute
+    /// on the parameter stays on the parameter, so a constraint meant for the property is silently
+    /// never seen. <c>"property"</c> is the target that fixes it; <c>"return"</c>, <c>"field"</c> and
+    /// <c>"assembly"</c> behave the same way.
+    /// </remarks>
+    public string? Target { get; set; }
+
     protected override void WriteComponentOutput(IOutputContext outputContext)
+    {
+        outputContext.AddImportNamespace(_attributeType);
+
+        outputContext.WriteIndent("[");
+        WriteBody(outputContext);
+        outputContext.WriteLine("]");
+    }
+
+    /// <summary>
+    /// Writes the attribute with no indent and no trailing newline, for a position that is part of
+    /// a line rather than a line of its own - a parameter, say.
+    /// </summary>
+    public void WriteInline(IOutputContext outputContext)
+    {
+        outputContext.AddImportNamespace(_attributeType);
+
+        outputContext.Write("[");
+        WriteBody(outputContext);
+        outputContext.Write("] ");
+    }
+
+    private void WriteBody(IOutputContext outputContext)
     {
         var attributeName = _attributeType.Name;
 
@@ -25,11 +59,14 @@ public class AttributeDefinition : BaseOutputComponent
             attributeName = attributeName.Substring(0, attributeName.Length - AttributePostfix.Length);
         }
 
-        outputContext.AddImportNamespace(_attributeType);
+        if (!string.IsNullOrEmpty(Target))
+        {
+            outputContext.Write(Target!);
+            outputContext.Write(": ");
+        }
 
-        outputContext.WriteIndent($"[{attributeName}");
+        outputContext.Write(attributeName);
         WriteArguments(outputContext);
-        outputContext.WriteLine("]");
     }
 
     private void WriteArguments(IOutputContext outputContext)

--- a/CSharpAuthor/ParameterDefinition.cs
+++ b/CSharpAuthor/ParameterDefinition.cs
@@ -46,6 +46,16 @@ public class ParameterDefinition : InstanceDefinition
     {
         outputContext.AddImportNamespace(TypeDefinition);
 
+        // Inline, because a parameter is part of a line rather than a line of its own. Attributes
+        // could always be added to a parameter; they were simply never written.
+        if (AttributeDefinitions != null)
+        {
+            foreach (var attributeDefinition in AttributeDefinitions)
+            {
+                attributeDefinition.WriteInline(outputContext);
+            }
+        }
+
         if (This)
         {
             outputContext.Write(KeyWords.This);


### PR DESCRIPTION
Two gaps found while emitting attributed models from an OpenAPI build task.

## Parameter attributes were accepted and never written

`AddAttribute` is on `BaseOutputComponent`, so a `ParameterDefinition` could always be given one — but `WriteWithSignature` never emitted them. They silently vanished.

## Attribute targets could not be expressed

In a positional record the parameter and the property it declares occupy one syntactic position:

```csharp
public record Pet([property: Required] string Name);
```

Without `property:` the attribute stays on the parameter, where a source generator reading properties never sees it — the constraint is silently not applied. That is precisely what ValidationModules' `VM0051` warns about, so it is a known trap rather than a hypothetical.

`AttributeDefinition.Target` covers it, and works the same for `return`, `field` and `assembly`.

## Shape

`AttributeDefinition` gains `WriteInline` for a position that is part of a line rather than a line of its own. That and `WriteComponentOutput` share one body, so a target is written wherever an attribute is — standalone or inline.

## Tests

`ParameterAttributeTests`, 6 cases. 105 pass, including all 99 that existed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9nw6izRwGZ7BLa7RqwMZg