### PR TITLE
Build type parameter constraints part by part

### DIFF
--- a/CSharpAuthor.Tests/ClassDefinitionTests/ConstraintDefinitionTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/ConstraintDefinitionTests.cs
@@ -1,0 +1,237 @@
+using System;
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+/// <summary>
+/// A where clause could always be assigned as a rendered string. These cover building one part by
+/// part, where the ordering rules C# fixes — one primary constraint first, new() last — are the thing
+/// worth not repeating in every caller.
+/// </summary>
+public class ConstraintDefinitionTests
+{
+    [Fact]
+    public void ClassConstraint()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddConstraint("T").Class();
+
+        AssertEqual.WithoutNewLine(
+            @"public class Box<T> where T : class
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    /// <summary>
+    /// Added out of order and written in order, which is the point: a caller reading a symbol takes
+    /// the parts as the symbol reports them.
+    /// </summary>
+    [Fact]
+    public void PartsAreWrittenInTheOrderCSharpRequires()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+
+        var constraint = classDefinition.AddConstraint("T");
+        constraint.DefaultConstructor();
+        constraint.Implements(TypeDefinition.Get("Ns", "IThing"));
+        constraint.Class();
+
+        AssertEqual.WithoutNewLine(
+            @"public class Box<T> where T : class, IThing, new()
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    [Fact]
+    public void SeveralParametersEachGetTheirOwnClause()
+    {
+        var classDefinition = new ClassDefinition("Pair");
+        classDefinition.AddGenericParameter("TKey");
+        classDefinition.AddGenericParameter("TValue");
+        classDefinition.AddConstraint("TKey").NotNull();
+        classDefinition.AddConstraint("TValue").Class();
+
+        AssertEqual.WithoutNewLine(
+            @"public class Pair<TKey, TValue> where TKey : notnull where TValue : class
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    [Fact]
+    public void ConstraintsFollowTheBaseTypes()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddBaseType(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "Ns",
+                "Container",
+                new ITypeDefinition[] { new TypeParameterDefinition("T") }));
+        classDefinition.AddConstraint("T").Class();
+
+        AssertEqual.WithoutNewLine(
+            @"public class Box<T> : Container<T> where T : class
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    [Theory]
+    [InlineData("struct")]
+    [InlineData("unmanaged")]
+    [InlineData("notnull")]
+    public void PrimaryConstraints(string keyword)
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+
+        var constraint = classDefinition.AddConstraint("T");
+
+        switch (keyword)
+        {
+            case "struct":
+                constraint.Struct();
+                break;
+            case "unmanaged":
+                constraint.Unmanaged();
+                break;
+            default:
+                constraint.NotNull();
+                break;
+        }
+
+        Assert.Contains($"where T : {keyword}", Write(classDefinition));
+    }
+
+    [Fact]
+    public void NullableClassConstraint()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddConstraint("T").Class(nullable: true);
+
+        Assert.Contains("where T : class?", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// The same parameter asked for twice is one clause. Two <c>where T</c> clauses on one type do
+    /// not compile, and a caller collecting constraints in a loop is exactly where that would happen.
+    /// </summary>
+    [Fact]
+    public void AskingTwiceForOneParameterExtendsTheSameClause()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddConstraint("T").Class();
+        classDefinition.AddConstraint("T").Implements(TypeDefinition.Get("Ns", "IThing"));
+
+        AssertEqual.WithoutNewLine(
+            @"public class Box<T> where T : class, IThing
+{
+}
+",
+            Write(classDefinition));
+
+        Assert.Single(classDefinition.Constraints);
+    }
+
+    [Fact]
+    public void AnEmptyConstraintWritesNothing()
+    {
+        var classDefinition = new ClassDefinition("Box");
+        classDefinition.AddGenericParameter("T");
+        classDefinition.AddConstraint("T");
+
+        AssertEqual.WithoutNewLine(
+            @"public class Box<T>
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    /// <summary>
+    /// The rendered form still works, and is written before any built one.
+    /// </summary>
+    [Fact]
+    public void WhereStatementAndAddConstraintCoexist()
+    {
+        var classDefinition = new ClassDefinition("Pair");
+        classDefinition.AddGenericParameter("TKey");
+        classDefinition.AddGenericParameter("TValue");
+        classDefinition.WhereStatement = new CodeOutputComponent(" where TKey : notnull") { Indented = false };
+        classDefinition.AddConstraint("TValue").Class();
+
+        AssertEqual.WithoutNewLine(
+            @"public class Pair<TKey, TValue> where TKey : notnull where TValue : class
+{
+}
+",
+            Write(classDefinition));
+    }
+
+    [Fact]
+    public void TwoPrimaryConstraintsThrow()
+    {
+        var constraint = new ConstraintDefinition("T").Class();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => constraint.Struct());
+
+        Assert.Contains("only one", exception.Message);
+    }
+
+    /// <summary>
+    /// <c>struct</c> already guarantees a default constructor, and <c>where T : struct, new()</c> is
+    /// CS0451. Caught here rather than by the consumer's compiler.
+    /// </summary>
+    [Fact]
+    public void StructWithDefaultConstructorThrows()
+    {
+        var constraint = new ConstraintDefinition("T").Struct();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => constraint.DefaultConstructor());
+
+        Assert.Contains("new()", exception.Message);
+    }
+
+    [Fact]
+    public void DefaultConstructorThenStructThrows()
+    {
+        var constraint = new ConstraintDefinition("T").DefaultConstructor();
+
+        Assert.Throws<InvalidOperationException>(() => constraint.Unmanaged());
+    }
+
+    [Fact]
+    public void RepeatingTheSamePrimaryConstraintIsAllowed()
+    {
+        var constraint = new ConstraintDefinition("T").Class().Class();
+
+        Assert.False(constraint.IsEmpty);
+    }
+
+    [Fact]
+    public void AConstraintHasToNameItsParameter()
+    {
+        Assert.Throws<ArgumentException>(() => new ConstraintDefinition(" "));
+    }
+
+    private static string Write(ClassDefinition classDefinition)
+    {
+        var context = new OutputContext();
+
+        classDefinition.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor.Tests/MethodTests/MethodConstraintTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/MethodConstraintTests.cs
@@ -1,0 +1,57 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.MethodTests;
+
+public class MethodConstraintTests
+{
+    [Fact]
+    public void GenericMethodWithConstraint()
+    {
+        var method = new MethodDefinition("Pick");
+        method.Modifiers |= ComponentModifier.Public;
+        method.AddGenericParameter(new TypeParameterDefinition("T"));
+        method.SetReturnType(new TypeParameterDefinition("T"));
+        method.AddParameter(new TypeParameterDefinition("T"), "item");
+        method.AddConstraint("T").Class();
+        method.Return("item");
+
+        AssertEqual.WithoutNewLine(
+            @"public T Pick<T>(T item) where T : class
+{
+    return item;
+}
+",
+            Write(method));
+    }
+
+    /// <summary>
+    /// The shape a forwarding wrapper needs: the constraints of the member it forwards to, repeated
+    /// so the call satisfies them.
+    /// </summary>
+    [Fact]
+    public void SeveralParametersEachGetTheirOwnClause()
+    {
+        var method = new MethodDefinition("Convert");
+        method.Modifiers |= ComponentModifier.Public;
+        method.AddGenericParameter(new TypeParameterDefinition("TIn"));
+        method.AddGenericParameter(new TypeParameterDefinition("TOut"));
+        method.SetReturnType(new TypeParameterDefinition("TOut"));
+        method.AddParameter(new TypeParameterDefinition("TIn"), "value");
+        method.AddConstraint("TIn").Implements(TypeDefinition.Get("Ns", "IThing"));
+        method.AddConstraint("TOut").Class().DefaultConstructor();
+        method.Return("default(TOut)");
+
+        Assert.Contains(
+            "public TOut Convert<TIn, TOut>(TIn value) where TIn : IThing where TOut : class, new()",
+            Write(method));
+    }
+
+    private static string Write(MethodDefinition method)
+    {
+        var context = new OutputContext();
+
+        method.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor/ClassDefinition.cs
+++ b/CSharpAuthor/ClassDefinition.cs
@@ -24,6 +24,7 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
     private readonly List<IOutputComponent> _otherComponents = new();
     private readonly List<ITypeDefinition> _genericParameters = new();
     private readonly List<EventDefinition> _events = new();
+    private readonly List<ConstraintDefinition> _constraints = new();
 
     public ClassDefinition(string name)
     {
@@ -54,7 +55,41 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
     /// <summary>
     /// The constraint clause, written after the base types: <c>where T : class, new()</c>.
     /// </summary>
+    /// <remarks>
+    /// A clause the caller has already rendered. <see cref="AddConstraint"/> builds one part by part
+    /// instead, and the two can be used together — this is written first.
+    /// </remarks>
     public IOutputComponent? WhereStatement { get; set; }
+
+    /// <summary>
+    /// The constraints declared through <see cref="AddConstraint"/>.
+    /// </summary>
+    public IReadOnlyList<ConstraintDefinition> Constraints => _constraints;
+
+    /// <summary>
+    /// Constrains one of this type's parameters, written after the base types.
+    /// </summary>
+    /// <remarks>
+    /// Returns the constraint so its parts can be added in any order; they are written in the order
+    /// C# requires. Calling this twice for one parameter returns the same constraint rather than
+    /// declaring a second <c>where</c> for it, which would not compile.
+    /// </remarks>
+    public ConstraintDefinition AddConstraint(string typeParameter)
+    {
+        foreach (var existing in _constraints)
+        {
+            if (existing.TypeParameter == typeParameter)
+            {
+                return existing;
+            }
+        }
+
+        var constraint = new ConstraintDefinition(typeParameter);
+
+        _constraints.Add(constraint);
+
+        return constraint;
+    }
 
     public ClassDefinition AddGenericParameter(ITypeDefinition typeDefinition)
     {
@@ -448,8 +483,20 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
             _baseTypes.OutputCommaSeparatedList(outputContext);
         }
 
-        // After the base types, which is where C# puts it.
+        // After the base types, which is where C# puts them.
         WhereStatement?.WriteOutput(outputContext);
+
+        foreach (var constraint in _constraints)
+        {
+            if (constraint.IsEmpty)
+            {
+                continue;
+            }
+
+            outputContext.WriteSpace();
+
+            constraint.WriteOutput(outputContext);
+        }
 
         if (terminator != null)
         {

--- a/CSharpAuthor/ConstraintDefinition.cs
+++ b/CSharpAuthor/ConstraintDefinition.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// The constraints on one type parameter, written as <c>where T : class, IComparable&lt;T&gt;, new()</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>where</c> clause could always be written by assigning a <c>CodeOutputComponent</c> to
+/// <see cref="ClassDefinition.WhereStatement"/>, and for a clause a generator already holds as text
+/// that is still the shortest route. Building one part by part is where the string gets fiddly,
+/// because C# fixes the order and the compiler is the only thing that checks it:
+/// </para>
+/// <list type="bullet">
+/// <item>the primary constraint, if any, comes first and there is at most one</item>
+/// <item>interfaces and base types come next</item>
+/// <item><c>new()</c> comes last, and cannot be combined with <c>struct</c> or <c>unmanaged</c>,
+/// which already imply it</item>
+/// </list>
+/// <para>
+/// Assembling that by hand puts the ordering rules in every caller. This holds the parts and writes
+/// them in the order C# requires, so a caller adds what it read from a symbol in whatever order it
+/// read them.
+/// </para>
+/// <example>
+/// <code>
+/// classDefinition.AddConstraint("T").Class().Implements(comparable).DefaultConstructor();
+/// // where T : class, IComparable&lt;T&gt;, new()
+/// </code>
+/// </example>
+/// </remarks>
+public class ConstraintDefinition
+{
+    private readonly List<ITypeDefinition> _types = new();
+    private string? _primary;
+    private bool _defaultConstructor;
+
+    public ConstraintDefinition(string typeParameter)
+    {
+        if (string.IsNullOrWhiteSpace(typeParameter))
+        {
+            throw new ArgumentException("A constraint has to name the type parameter it constrains.",
+                nameof(typeParameter));
+        }
+
+        TypeParameter = typeParameter;
+    }
+
+    /// <summary>
+    /// The parameter being constrained, which is the name after <c>where</c>.
+    /// </summary>
+    public string TypeParameter { get; }
+
+    /// <summary>
+    /// Whether anything has been added. An empty constraint writes nothing rather than a
+    /// <c>where T :</c> with nothing after it.
+    /// </summary>
+    public bool IsEmpty => _primary == null && _types.Count == 0 && !_defaultConstructor;
+
+    /// <summary>
+    /// <c>where T : class</c>, or <c>class?</c> when <paramref name="nullable"/>.
+    /// </summary>
+    public ConstraintDefinition Class(bool nullable = false) => Primary(nullable ? "class?" : "class");
+
+    /// <summary>
+    /// <c>where T : struct</c>. Implies a default constructor, so <see cref="DefaultConstructor"/>
+    /// cannot be added as well.
+    /// </summary>
+    public ConstraintDefinition Struct() => Primary("struct");
+
+    /// <summary>
+    /// <c>where T : unmanaged</c>. Narrower than <see cref="Struct"/>, and likewise implies a
+    /// default constructor.
+    /// </summary>
+    public ConstraintDefinition Unmanaged() => Primary("unmanaged");
+
+    /// <summary>
+    /// <c>where T : notnull</c>.
+    /// </summary>
+    public ConstraintDefinition NotNull() => Primary("notnull");
+
+    /// <summary>
+    /// <c>where T : default</c>, which is how an override releases a constraint it inherited.
+    /// </summary>
+    public ConstraintDefinition Default() => Primary("default");
+
+    /// <summary>
+    /// A base class or interface the argument has to derive from or implement. Several may be added,
+    /// and they are written in the order they were added.
+    /// </summary>
+    /// <remarks>
+    /// A base class and an interface occupy the same position in the clause and C# does not
+    /// distinguish them there, so one method covers both. A base class still has to be written before
+    /// any interface, which is the caller's ordering to keep.
+    /// </remarks>
+    public ConstraintDefinition Implements(ITypeDefinition type)
+    {
+        if (type == null)
+        {
+            throw new ArgumentNullException(nameof(type));
+        }
+
+        _types.Add(type);
+
+        return this;
+    }
+
+    /// <summary>
+    /// <c>new()</c>, written last.
+    /// </summary>
+    public ConstraintDefinition DefaultConstructor()
+    {
+        if (_primary is "struct" or "unmanaged")
+        {
+            throw new InvalidOperationException(
+                $"'{TypeParameter}' is constrained to '{_primary}', which already guarantees a " +
+                "default constructor, so new() cannot be added as well.");
+        }
+
+        _defaultConstructor = true;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Writes <c>where T : ...</c>, with no leading or trailing space.
+    /// </summary>
+    public void WriteOutput(IOutputContext outputContext)
+    {
+        if (IsEmpty)
+        {
+            return;
+        }
+
+        outputContext.Write("where ");
+        outputContext.Write(TypeParameter);
+        outputContext.Write(" : ");
+
+        var written = false;
+
+        if (_primary != null)
+        {
+            outputContext.Write(_primary);
+            written = true;
+        }
+
+        foreach (var type in _types)
+        {
+            if (written)
+            {
+                outputContext.Write(", ");
+            }
+
+            outputContext.Write(type);
+            written = true;
+        }
+
+        if (_defaultConstructor)
+        {
+            if (written)
+            {
+                outputContext.Write(", ");
+            }
+
+            outputContext.Write("new()");
+        }
+    }
+
+    /// <summary>
+    /// The one primary constraint, which has to come first and cannot be joined by another.
+    /// </summary>
+    private ConstraintDefinition Primary(string keyword)
+    {
+        if (_primary != null && _primary != keyword)
+        {
+            throw new InvalidOperationException(
+                $"'{TypeParameter}' is already constrained to '{_primary}', and '{keyword}' is also a " +
+                "primary constraint. A type parameter may have only one.");
+        }
+
+        if (_defaultConstructor && keyword is "struct" or "unmanaged")
+        {
+            throw new InvalidOperationException(
+                $"'{TypeParameter}' already has a new() constraint, which '{keyword}' implies. " +
+                "The two cannot be combined.");
+        }
+
+        _primary = keyword;
+
+        return this;
+    }
+}

--- a/CSharpAuthor/MethodDefinition.cs
+++ b/CSharpAuthor/MethodDefinition.cs
@@ -8,6 +8,7 @@ public class MethodDefinition : BaseBlockDefinition, INamedComponent
 {
     protected readonly List<ParameterDefinition> ParameterList = new ();
     private readonly List<ITypeDefinition> _genericParameters = new();
+    private readonly List<ConstraintDefinition> _constraints = new();
     protected int VariableCount = 1;
         
     private ITypeDefinition? _returnType;
@@ -23,7 +24,41 @@ public class MethodDefinition : BaseBlockDefinition, INamedComponent
 
     public List<ITypeDefinition> GenericParameters => _genericParameters;
 
+    /// <remarks>
+    /// A clause the caller has already rendered. <see cref="AddConstraint"/> builds one part by part
+    /// instead, and the two can be used together — this is written first.
+    /// </remarks>
     public IOutputComponent? WhereStatement { get; set; }
+
+    /// <summary>
+    /// The constraints declared through <see cref="AddConstraint"/>.
+    /// </summary>
+    public IReadOnlyList<ConstraintDefinition> Constraints => _constraints;
+
+    /// <summary>
+    /// Constrains one of this method's type parameters, written after the parameter list.
+    /// </summary>
+    /// <remarks>
+    /// Returns the constraint so its parts can be added in any order; they are written in the order
+    /// C# requires. Calling this twice for one parameter returns the same constraint rather than
+    /// declaring a second <c>where</c> for it, which would not compile.
+    /// </remarks>
+    public ConstraintDefinition AddConstraint(string typeParameter)
+    {
+        foreach (var existing in _constraints)
+        {
+            if (existing.TypeParameter == typeParameter)
+            {
+                return existing;
+            }
+        }
+
+        var constraint = new ConstraintDefinition(typeParameter);
+
+        _constraints.Add(constraint);
+
+        return constraint;
+    }
     
     public ITypeDefinition? InterfaceImplementation { get; set; }
 
@@ -169,6 +204,18 @@ public class MethodDefinition : BaseBlockDefinition, INamedComponent
     protected virtual void WriteEndOfMethodSignature(IOutputContext outputContext)
     {
         WhereStatement?.WriteOutput(outputContext);
+
+        foreach (var constraint in _constraints)
+        {
+            if (constraint.IsEmpty)
+            {
+                continue;
+            }
+
+            outputContext.WriteSpace();
+
+            constraint.WriteOutput(outputContext);
+        }
         
         outputContext.WriteLine();
     }


### PR DESCRIPTION
A `where` clause could always be written by assigning a rendered `CodeOutputComponent` to `WhereStatement`, and for a clause a generator already holds as text that stays the shortest route. Building one from parts is where the string gets fiddly, because C# fixes the order and only the consumer's compiler checks it:

- one primary constraint, first — `class` / `struct` / `unmanaged` / `notnull` / a base type
- interfaces next
- `new()` last, and CS0451 alongside `struct` or `unmanaged`, which already imply it

Assembling that by hand puts the ordering rules in every caller.

## What this adds

`ConstraintDefinition` holds the parts and writes them in the order C# requires, so a caller adds what it read from a symbol in whatever order the symbol reported it:

```csharp
var constraint = classDefinition.AddConstraint("T");
constraint.DefaultConstructor();
constraint.Implements(TypeDefinition.Get("Ns", "IThing"));
constraint.Class();

// where T : class, IThing, new()
```

`AddConstraint` is on `ClassDefinition` and `MethodDefinition`, and returns the *same* constraint when a parameter is named twice — two `where T` clauses for one parameter do not compile, and a caller collecting constraints in a loop is exactly where that would happen.

The illegal combinations throw rather than reaching the consumer's build: two primary constraints, and `new()` alongside `struct`/`unmanaged`.

`WhereStatement` is untouched and is written first, so a rendered clause and a built one can be mixed.

## Verification

123 tests pass, and the output was compiled rather than only compared as text — a generic wrapper repeating a constrained service's constraints, a nested type repeating them again, and a constrained generic method alongside them:

```csharp
internal class Repository_Intercepted<T> : global::Generated.IRepository<T>
    where T : class, global::Generated.IEntity, new()
{
    public TItem Pick<TItem>(TItem item) where TItem : struct { … }

    private sealed class State<T> where T : class, global::Generated.IEntity, new() { }
}
```

No version bump here, matching how previous feature PRs landed with a separate bump PR after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np5LZpJ2PPStWVcrNXfmD5