### PR TITLE
Base types with constructor arguments, and comments that span lines

### DIFF
--- a/CSharpAuthor.Tests/AssertEqual.cs
+++ b/CSharpAuthor.Tests/AssertEqual.cs
@@ -8,4 +8,18 @@ internal static class AssertEqual
     {
         Assert.Equal(expected.Replace("\r\n","\n"), actual.Replace("\r\n","\n"));
     }
+
+    /// <summary>
+    /// <c>Assert.Contains</c> with line endings normalised on both sides.
+    /// </summary>
+    /// <remarks>
+    /// A multi-line expectation cannot be compared verbatim. String literals in a test file take
+    /// their line endings from the checkout - CRLF on Windows - while the writer emits its own, so
+    /// an assertion that passes on one platform fails on the other, and the failure message prints
+    /// the two as identical. That is what this and <see cref="WithoutNewLine"/> exist to avoid.
+    /// </remarks>
+    public static void ContainsWithoutNewLine(string expected, string actual)
+    {
+        Assert.Contains(expected.Replace("\r\n","\n"), actual.Replace("\r\n","\n"));
+    }
 }

--- a/CSharpAuthor.Tests/ClassDefinitionTests/BaseTypeArgumentTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/BaseTypeArgumentTests.cs
@@ -1,0 +1,118 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+/// <summary>
+/// Base types that take constructor arguments.
+/// </summary>
+/// <remarks>
+/// A base list used to be bare type names, so a derived record could name its base but not pass
+/// anything to it - which meant <c>record Dog(string Id) : Pet(Id)</c> could not be written at all
+/// and a generator emitting a hierarchy had to give up positional records for init-only
+/// properties.
+/// </remarks>
+public class BaseTypeArgumentTests
+{
+    [Fact]
+    public void ARecordPassesItsParametersToItsBase()
+    {
+        var classDefinition = new ClassDefinition("Dog") {
+            TypeKeyword = ClassKeyword.Record,
+            TerminateWithSemicolon = true,
+            Modifiers = ComponentModifier.Public
+        };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+        constructor.AddParameter(typeof(string), "Id");
+        constructor.AddParameter(typeof(string), "Breed");
+
+        classDefinition.AddBaseType(
+            TypeDefinition.Get("Pets", "Pet"), Argument("Id"));
+
+        AssertEqual.WithoutNewLine(
+            "public record Dog(string Id, string Breed) : Pet(Id);\n", Write(classDefinition));
+    }
+
+    [Fact]
+    public void SeveralArgumentsAreCommaSeparated()
+    {
+        var classDefinition = new ClassDefinition("Dog") {
+            TypeKeyword = ClassKeyword.Record,
+            TerminateWithSemicolon = true,
+            Modifiers = ComponentModifier.Public
+        };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+        constructor.AddParameter(typeof(string), "Id");
+        constructor.AddParameter(typeof(string), "Name");
+
+        classDefinition.AddBaseType(
+            TypeDefinition.Get("Pets", "Pet"), Argument("Id"), Argument("Name"));
+
+        AssertEqual.WithoutNewLine(
+            "public record Dog(string Id, string Name) : Pet(Id, Name);\n", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// A base type with no arguments writes exactly as it did before, which is what keeps every
+    /// interface in a base list unaffected.
+    /// </summary>
+    [Fact]
+    public void ABaseTypeWithoutArgumentsIsUnchanged()
+    {
+        var classDefinition = new ClassDefinition("Dog") {
+            Modifiers = ComponentModifier.Public
+        };
+
+        classDefinition.AddBaseType(TypeDefinition.Get("Pets", "Pet"));
+
+        AssertEqual.WithoutNewLine("public class Dog : Pet\n{\n}\n", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// The base class carries the arguments; interfaces alongside it do not.
+    /// </summary>
+    [Fact]
+    public void OnlyTheEntryCarryingArgumentsGetsThem()
+    {
+        var classDefinition = new ClassDefinition("Dog") {
+            Modifiers = ComponentModifier.Public
+        };
+
+        classDefinition.AddBaseType(TypeDefinition.Get("Pets", "Pet"), Argument("id"));
+        classDefinition.AddBaseType(TypeDefinition.Get("Pets", "IAnimal"));
+
+        AssertEqual.WithoutNewLine(
+            "public class Dog : Pet(id), IAnimal\n{\n}\n", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// Adding the same base twice is still one entry, as it was before arguments existed.
+    /// </summary>
+    [Fact]
+    public void ABaseTypeIsNotAddedTwice()
+    {
+        var classDefinition = new ClassDefinition("Dog") {
+            Modifiers = ComponentModifier.Public
+        };
+
+        classDefinition.AddBaseType(TypeDefinition.Get("Pets", "Pet"));
+        classDefinition.AddBaseType(TypeDefinition.Get("Pets", "Pet"), Argument("id"));
+
+        AssertEqual.WithoutNewLine("public class Dog : Pet\n{\n}\n", Write(classDefinition));
+    }
+
+    private static IOutputComponent Argument(string text) =>
+        new CodeOutputComponent(text) { Indented = false };
+
+    private static string Write(ClassDefinition classDefinition)
+    {
+        var outputContext = new OutputContext();
+
+        classDefinition.WriteOutput(outputContext);
+
+        return outputContext.Output();
+    }
+}

--- a/CSharpAuthor.Tests/CommentTests/DeclarationCommentTests.cs
+++ b/CSharpAuthor.Tests/CommentTests/DeclarationCommentTests.cs
@@ -1,0 +1,127 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.CommentTests;
+
+/// <summary>
+/// Declarations whose comments used to go nowhere.
+/// </summary>
+/// <remarks>
+/// <c>Comment</c> is inherited from <see cref="BaseOutputComponent"/> by everything, and the base
+/// <c>WriteComment</c> does nothing - so a component that never overrode it accepted a comment,
+/// read as documented at the call site, and emitted none. Enums and their members were both in
+/// that position, and a positional record could document itself but not the properties it declares
+/// in its header.
+/// </remarks>
+public class DeclarationCommentTests
+{
+    [Fact]
+    public void AnEnumWritesItsSummary()
+    {
+        var enumDefinition = new EnumDefinition("Status") { Comment = "How far along a pet is." };
+
+        enumDefinition.AddValue("Available");
+
+        Assert.Contains(
+            "/// <summary>\n/// How far along a pet is.\n/// </summary>\npublic enum Status",
+            Write(enumDefinition));
+    }
+
+    [Fact]
+    public void AnEnumMemberWritesItsSummary()
+    {
+        var enumDefinition = new EnumDefinition("Status");
+
+        enumDefinition.AddValue("Available").Comment = "Ready to be adopted.";
+        enumDefinition.AddValue("Pending");
+
+        var output = Write(enumDefinition);
+
+        Assert.Contains("    /// <summary>\n    /// Ready to be adopted.\n    /// </summary>\n    Available,", output);
+
+        // The undocumented member is untouched.
+        Assert.Contains("    Pending,", output);
+    }
+
+    /// <summary>
+    /// A positional record's properties are documented with <c>&lt;param&gt;</c> on the type,
+    /// which is the only place the compiler accepts it.
+    /// </summary>
+    [Fact]
+    public void ARecordDocumentsItsPositionalProperties()
+    {
+        var classDefinition = new ClassDefinition("Pet") {
+            TypeKeyword = ClassKeyword.Record,
+            TerminateWithSemicolon = true,
+            Modifiers = ComponentModifier.Public,
+            Comment = "A pet."
+        };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+        constructor.AddParameter(typeof(string), "Id").Comment = "Opaque identifier.";
+        constructor.AddParameter(typeof(string), "Name").Comment = "Display name.";
+
+        AssertEqual.WithoutNewLine(
+            "/// <summary>\n" +
+            "/// A pet.\n" +
+            "/// </summary>\n" +
+            "/// <param name=\"Id\">Opaque identifier.</param>\n" +
+            "/// <param name=\"Name\">Display name.</param>\n" +
+            "public record Pet(string Id, string Name);\n",
+            Write(classDefinition));
+    }
+
+    /// <summary>
+    /// An undocumented parameter contributes no element, so a partly-documented record does not
+    /// emit empty ones.
+    /// </summary>
+    [Fact]
+    public void UndocumentedParametersAreSkipped()
+    {
+        var classDefinition = new ClassDefinition("Pet") {
+            TypeKeyword = ClassKeyword.Record,
+            TerminateWithSemicolon = true,
+            Modifiers = ComponentModifier.Public,
+            Comment = "A pet."
+        };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+        constructor.AddParameter(typeof(string), "Id").Comment = "Opaque identifier.";
+        constructor.AddParameter(typeof(string), "Name");
+
+        var output = Write(classDefinition);
+
+        Assert.Contains("""<param name="Id">""", output);
+        Assert.DoesNotContain("""<param name="Name">""", output);
+    }
+
+    /// <summary>
+    /// A class with no summary writes nothing, even where its parameters carry comments — the
+    /// elements have no summary to hang from.
+    /// </summary>
+    [Fact]
+    public void NoSummaryMeansNoComment()
+    {
+        var classDefinition = new ClassDefinition("Pet") {
+            TypeKeyword = ClassKeyword.Record,
+            TerminateWithSemicolon = true,
+            Modifiers = ComponentModifier.Public
+        };
+
+        var constructor = classDefinition.AddConstructor();
+        constructor.IsPrimary = true;
+        constructor.AddParameter(typeof(string), "Id").Comment = "Opaque identifier.";
+
+        Assert.DoesNotContain("///", Write(classDefinition));
+    }
+
+    private static string Write(IOutputComponent component)
+    {
+        var outputContext = new OutputContext();
+
+        component.WriteOutput(outputContext);
+
+        return outputContext.Output();
+    }
+}

--- a/CSharpAuthor.Tests/CommentTests/DeclarationCommentTests.cs
+++ b/CSharpAuthor.Tests/CommentTests/DeclarationCommentTests.cs
@@ -21,7 +21,7 @@ public class DeclarationCommentTests
 
         enumDefinition.AddValue("Available");
 
-        Assert.Contains(
+        AssertEqual.ContainsWithoutNewLine(
             "/// <summary>\n/// How far along a pet is.\n/// </summary>\npublic enum Status",
             Write(enumDefinition));
     }
@@ -36,10 +36,10 @@ public class DeclarationCommentTests
 
         var output = Write(enumDefinition);
 
-        Assert.Contains("    /// <summary>\n    /// Ready to be adopted.\n    /// </summary>\n    Available,", output);
+        AssertEqual.ContainsWithoutNewLine("    /// <summary>\n    /// Ready to be adopted.\n    /// </summary>\n    Available,", output);
 
         // The undocumented member is untouched.
-        Assert.Contains("    Pending,", output);
+        AssertEqual.ContainsWithoutNewLine("    Pending,", output);
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public class DeclarationCommentTests
 
         var output = Write(classDefinition);
 
-        Assert.Contains("""<param name="Id">""", output);
+        AssertEqual.ContainsWithoutNewLine("""<param name="Id">""", output);
         Assert.DoesNotContain("""<param name="Name">""", output);
     }
 

--- a/CSharpAuthor.Tests/CommentTests/MultiLineCommentTests.cs
+++ b/CSharpAuthor.Tests/CommentTests/MultiLineCommentTests.cs
@@ -36,8 +36,12 @@ public class MultiLineCommentTests
             Comment = "First line.\r\nSecond line."
         };
 
-        Assert.DoesNotContain("\r", Write(classDefinition));
-        Assert.Contains("/// First line.\n/// Second line.", Write(classDefinition));
+        // Real line breaks first: AppendLine writes Environment.NewLine, so on Windows the output
+        // carries carriage returns by design. What must not survive is one inside the comment's own
+        // text, which is what is left once the line breaks are taken out.
+        Assert.DoesNotContain("\r", Write(classDefinition).Replace("\r\n", "\n"));
+
+        AssertEqual.ContainsWithoutNewLine("/// First line.\n/// Second line.", Write(classDefinition));
     }
 
     /// <summary>
@@ -51,7 +55,7 @@ public class MultiLineCommentTests
             Comment = "First paragraph.\n\nSecond paragraph."
         };
 
-        Assert.Contains("/// First paragraph.\n///\n/// Second paragraph.", Write(classDefinition));
+        AssertEqual.ContainsWithoutNewLine("/// First paragraph.\n///\n/// Second paragraph.", Write(classDefinition));
     }
 
     /// <summary>
@@ -65,7 +69,7 @@ public class MultiLineCommentTests
         var method = classDefinition.AddMethod("MyMethod");
         method.Comment = "First line.\nSecond line.";
 
-        Assert.Contains("    /// First line.\n    /// Second line.", Write(classDefinition));
+        AssertEqual.ContainsWithoutNewLine("    /// First line.\n    /// Second line.", Write(classDefinition));
     }
 
     /// <summary>
@@ -96,8 +100,8 @@ public class MultiLineCommentTests
 
         var output = Write(classDefinition);
 
-        Assert.Contains("""/// <param name="single">On one line.</param>""", output);
-        Assert.Contains(
+        AssertEqual.ContainsWithoutNewLine("""/// <param name="single">On one line.</param>""", output);
+        AssertEqual.ContainsWithoutNewLine(
             "/// <param name=\"wrapped\">\n    /// First line.\n    /// Second line.\n    /// </param>",
             output);
     }

--- a/CSharpAuthor.Tests/CommentTests/MultiLineCommentTests.cs
+++ b/CSharpAuthor.Tests/CommentTests/MultiLineCommentTests.cs
@@ -1,0 +1,113 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.CommentTests;
+
+/// <summary>
+/// Comments containing line breaks.
+/// </summary>
+/// <remarks>
+/// A comment used to be written as one <c>"/// " + Comment</c>, so a line break in it emitted a
+/// continuation line carrying neither the indent nor the marker - output that does not compile.
+/// Callers worked around it by flattening their prose, which is a poor answer for the one kind of
+/// text that arrives with paragraphs in it.
+/// </remarks>
+public class MultiLineCommentTests
+{
+    [Fact]
+    public void EveryLineOfASummaryCarriesTheMarker()
+    {
+        var classDefinition = new ClassDefinition("MyClass") {
+            Comment = "First line.\nSecond line."
+        };
+
+        AssertEqual.WithoutNewLine(
+            "/// <summary>\n/// First line.\n/// Second line.\n/// </summary>\npublic class MyClass\n{\n}\n",
+            Write(classDefinition));
+    }
+
+    /// <summary>
+    /// Windows line endings split the same way, rather than leaving a stray carriage return inside
+    /// the comment.
+    /// </summary>
+    [Fact]
+    public void CarriageReturnsAreNotCarriedThrough()
+    {
+        var classDefinition = new ClassDefinition("MyClass") {
+            Comment = "First line.\r\nSecond line."
+        };
+
+        Assert.DoesNotContain("\r", Write(classDefinition));
+        Assert.Contains("/// First line.\n/// Second line.", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// A blank line between paragraphs keeps its marker, and does not leave trailing whitespace
+    /// behind it.
+    /// </summary>
+    [Fact]
+    public void ABlankLineKeepsItsMarkerWithoutTrailingSpace()
+    {
+        var classDefinition = new ClassDefinition("MyClass") {
+            Comment = "First paragraph.\n\nSecond paragraph."
+        };
+
+        Assert.Contains("/// First paragraph.\n///\n/// Second paragraph.", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// Indentation applies to every line, not only the first.
+    /// </summary>
+    [Fact]
+    public void NestedComponentsIndentEveryLine()
+    {
+        var classDefinition = new ClassDefinition("MyClass");
+
+        var method = classDefinition.AddMethod("MyMethod");
+        method.Comment = "First line.\nSecond line.";
+
+        Assert.Contains("    /// First line.\n    /// Second line.", Write(classDefinition));
+    }
+
+    /// <summary>
+    /// A single-line comment is written exactly as it always was.
+    /// </summary>
+    [Fact]
+    public void ASingleLineCommentIsUnchanged()
+    {
+        var classDefinition = new ClassDefinition("MyClass") { Comment = "One line." };
+
+        AssertEqual.WithoutNewLine(
+            "/// <summary>\n/// One line.\n/// </summary>\npublic class MyClass\n{\n}\n",
+            Write(classDefinition));
+    }
+
+    /// <summary>
+    /// A <c>&lt;param&gt;</c> stays on one line where it fits, and opens out where it does not.
+    /// </summary>
+    [Fact]
+    public void ParamElementsOpenOutOnlyWhenTheyHaveTo()
+    {
+        var classDefinition = new ClassDefinition("MyClass");
+
+        var method = classDefinition.AddMethod("MyMethod");
+        method.Comment = "A method.";
+        method.AddParameter(typeof(int), "single").Comment = "On one line.";
+        method.AddParameter(typeof(int), "wrapped").Comment = "First line.\nSecond line.";
+
+        var output = Write(classDefinition);
+
+        Assert.Contains("""/// <param name="single">On one line.</param>""", output);
+        Assert.Contains(
+            "/// <param name=\"wrapped\">\n    /// First line.\n    /// Second line.\n    /// </param>",
+            output);
+    }
+
+    private static string Write(ClassDefinition classDefinition)
+    {
+        var outputContext = new OutputContext();
+
+        classDefinition.WriteOutput(outputContext);
+
+        return outputContext.Output();
+    }
+}

--- a/CSharpAuthor/BaseTypeReference.cs
+++ b/CSharpAuthor/BaseTypeReference.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// A type in a base list, and the arguments its constructor is called with.
+/// </summary>
+/// <remarks>
+/// The arguments are what makes <c>record Dog(string Id) : Pet(Id)</c> expressible. A base list
+/// entry with none of them writes exactly as it did when the list held bare types, so an interface
+/// - which can never take arguments - is unaffected.
+/// </remarks>
+internal readonly struct BaseTypeReference
+{
+    private readonly IReadOnlyList<IOutputComponent> _arguments;
+
+    public BaseTypeReference(ITypeDefinition type, IReadOnlyList<IOutputComponent> arguments)
+    {
+        Type = type;
+        _arguments = arguments;
+    }
+
+    public ITypeDefinition Type { get; }
+
+    public void WriteOutput(IOutputContext outputContext)
+    {
+        outputContext.Write(Type);
+
+        if (_arguments == null || _arguments.Count == 0)
+        {
+            return;
+        }
+
+        outputContext.Write("(");
+
+        _arguments.OutputCommaSeparatedList(outputContext);
+
+        outputContext.Write(")");
+    }
+}

--- a/CSharpAuthor/ClassDefinition.cs
+++ b/CSharpAuthor/ClassDefinition.cs
@@ -15,7 +15,7 @@ public enum ClassKeyword
 
 public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedComponent
 {
-    private readonly List<ITypeDefinition> _baseTypes = new();
+    private readonly List<BaseTypeReference> _baseTypes = new();
     private readonly List<FieldDefinition> _fields = new();
     private readonly List<ConstructorDefinition> _constructors = new();
     private readonly List<MethodDefinition> _methods = new();
@@ -281,10 +281,35 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
 
     public ClassDefinition AddBaseType(ITypeDefinition typeDefinition)
     {
-        if (!_baseTypes.Contains(typeDefinition))
+        return AddBaseType(typeDefinition, Array.Empty<IOutputComponent>());
+    }
+
+    /// <summary>
+    /// A base type, with the arguments its constructor is called with.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For a positional record this is the only way to say <c>record Dog(string Id, string Breed) :
+    /// Pet(Id)</c>. Without it a derived record could name its base but not pass anything to it, so
+    /// any generator emitting an inheritance hierarchy had to abandon positional records entirely
+    /// and fall back to init-only properties.
+    /// </para>
+    /// <para>
+    /// C# allows the arguments on the base class only, and it has to come first in the list. That
+    /// is the caller's to get right - this writes the arguments wherever they were attached.
+    /// </para>
+    /// </remarks>
+    public ClassDefinition AddBaseType(ITypeDefinition typeDefinition, params IOutputComponent[] arguments)
+    {
+        foreach (var existing in _baseTypes)
         {
-            _baseTypes.Add(typeDefinition);
+            if (existing.Type.Equals(typeDefinition))
+            {
+                return this;
+            }
         }
+
+        _baseTypes.Add(new BaseTypeReference(typeDefinition, arguments));
 
         return this;
     }
@@ -313,16 +338,43 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
         WriteClassClosing(outputContext);
     }
 
+    /// <summary>
+    /// The type's summary, followed by a <c>&lt;param&gt;</c> for each documented primary
+    /// constructor parameter.
+    /// </summary>
+    /// <remarks>
+    /// A positional record declares its properties in its header, so <c>&lt;param&gt;</c> on the
+    /// type is where documentation for them belongs - the same arrangement a method uses, and the
+    /// only place the compiler will accept it. Without this a record's properties could not be
+    /// documented at all, only the record itself.
+    /// </remarks>
     protected override void WriteComment(IOutputContext outputContext)
     {
         if (string.IsNullOrWhiteSpace(Comment))
         {
             return;
         }
-        
-        outputContext.WriteIndentedLine("/// <summary>");
-        outputContext.WriteIndentedLine($"/// {Comment}");
-        outputContext.WriteIndentedLine("/// </summary>");
+
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
+
+        foreach (var constructor in _constructors)
+        {
+            if (!constructor.IsPrimary)
+            {
+                continue;
+            }
+
+            foreach (var parameter in constructor.Parameters)
+            {
+                DocumentationComment.WriteElement(
+                    outputContext.WriteIndentedLine,
+                    "<param name=\"" + parameter.Name + "\">",
+                    "</param>",
+                    parameter.Comment);
+            }
+
+            break;
+        }
     }
 
     private void ApplyAllComponents(Action<IOutputComponent> componentAction, IOutputContext outputContext)
@@ -480,7 +532,8 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
         {
             outputContext.Write(" : ");
 
-            _baseTypes.OutputCommaSeparatedList(outputContext);
+            _baseTypes.OutputCommaSeparatedList(
+                outputContext, (context, baseType) => baseType.WriteOutput(context));
         }
 
         // After the base types, which is where C# puts them.

--- a/CSharpAuthor/DocumentationComment.cs
+++ b/CSharpAuthor/DocumentationComment.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// Writes the <c>///</c> lines of a documentation comment.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every component that had a comment wrote it as a single <c>"/// " + Comment</c>, so a comment
+/// containing a line break emitted continuation lines carrying neither the indent nor the marker.
+/// That is a syntax error rather than a formatting problem, which left callers collapsing their
+/// prose to one line before handing it over - and prose is exactly the thing that arrives with
+/// paragraphs in it.
+/// </para>
+/// <para>
+/// The single-line shape is unchanged, so nothing that was already correct moves.
+/// </para>
+/// </remarks>
+internal static class DocumentationComment
+{
+    /// <summary>
+    /// A <c>&lt;summary&gt;</c> element, one <c>///</c> line per line of the comment.
+    /// </summary>
+    public static void WriteSummary(Action<string> writeLine, string? comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+        {
+            return;
+        }
+
+        writeLine("/// <summary>");
+
+        WriteBody(writeLine, comment!);
+
+        writeLine("/// </summary>");
+    }
+
+    /// <summary>
+    /// An element that fits on one line where its content does - <c>&lt;param&gt;</c>,
+    /// <c>&lt;returns&gt;</c> - and opens out onto its own lines where it does not.
+    /// </summary>
+    public static void WriteElement(
+        Action<string> writeLine, string openTag, string closeTag, string? comment)
+    {
+        if (string.IsNullOrWhiteSpace(comment))
+        {
+            return;
+        }
+
+        if (!IsMultiLine(comment!))
+        {
+            writeLine("/// " + openTag + comment!.Trim() + closeTag);
+
+            return;
+        }
+
+        writeLine("/// " + openTag);
+
+        WriteBody(writeLine, comment!);
+
+        writeLine("/// " + closeTag);
+    }
+
+    private static void WriteBody(Action<string> writeLine, string comment)
+    {
+        foreach (var line in comment.Split('\n'))
+        {
+            var text = line.TrimEnd('\r').TrimEnd();
+
+            // A blank line keeps its marker but not a trailing space, which is what an editor
+            // strips on save and what would otherwise show up as a whitespace-only diff.
+            writeLine(text.Length == 0 ? "///" : "/// " + text);
+        }
+    }
+
+    private static bool IsMultiLine(string comment) =>
+        comment.IndexOf('\n') >= 0 || comment.IndexOf('\r') >= 0;
+}

--- a/CSharpAuthor/EnumDefinition.cs
+++ b/CSharpAuthor/EnumDefinition.cs
@@ -41,6 +41,16 @@ public class EnumDefinition : BaseOutputComponent, INamedComponent
         return enumValueDefinition;
     }
 
+    /// <summary>
+    /// An enum inherits <see cref="BaseOutputComponent.Comment"/> like every other declaration, and
+    /// used to be one of the two that never wrote it - so setting one compiled, read as documented,
+    /// and emitted nothing.
+    /// </summary>
+    protected override void WriteComment(IOutputContext outputContext)
+    {
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
+    }
+
     protected override void WriteComponentOutput(IOutputContext outputContext)
     {
         WriteEnumSignature(outputContext);

--- a/CSharpAuthor/EnumValueDefinition.cs
+++ b/CSharpAuthor/EnumValueDefinition.cs
@@ -15,6 +15,15 @@ public class EnumValueDefinition : BaseOutputComponent
 
     public object? Value { get; set; }
 
+    /// <summary>
+    /// The member's own documentation, which is where a specification's description of a single
+    /// enum value belongs. Silently dropped before this existed.
+    /// </summary>
+    protected override void WriteComment(IOutputContext outputContext)
+    {
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
+    }
+
     protected override void WriteComponentOutput(IOutputContext outputContext)
     {
         outputContext.WriteIndent();

--- a/CSharpAuthor/EventDefinition.cs
+++ b/CSharpAuthor/EventDefinition.cs
@@ -96,8 +96,6 @@ public class EventDefinition : BaseOutputComponent, INamedComponent
             return;
         }
 
-        outputContext.WriteIndentedLine("/// <summary>");
-        outputContext.WriteIndentedLine($"/// {Comment}");
-        outputContext.WriteIndentedLine("/// </summary>");
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
     }
 }

--- a/CSharpAuthor/FieldDefinition.cs
+++ b/CSharpAuthor/FieldDefinition.cs
@@ -54,8 +54,6 @@ public class FieldDefinition : BaseOutputComponent, INamedComponent
             return;
         }
         
-        outputContext.WriteLine("/// <summary>");
-        outputContext.WriteLine($"/// {Comment}");
-        outputContext.WriteLine("/// </summary>");
+        DocumentationComment.WriteSummary(outputContext.WriteLine, Comment);
     }
 }

--- a/CSharpAuthor/InterfaceDefinition.cs
+++ b/CSharpAuthor/InterfaceDefinition.cs
@@ -77,9 +77,7 @@ public class InterfaceDefinition : BaseOutputComponent, INamedComponent
             return;
         }
         
-        outputContext.WriteIndentedLine("/// <summary>");
-        outputContext.WriteIndentedLine($"/// {Comment}");
-        outputContext.WriteIndentedLine("/// </summary>");
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
     }
 
     private void WriteInterfaceClosing(IOutputContext outputContext)

--- a/CSharpAuthor/MethodDefinition.cs
+++ b/CSharpAuthor/MethodDefinition.cs
@@ -125,21 +125,24 @@ public class MethodDefinition : BaseBlockDefinition, INamedComponent
             return;
         }
         
-        outputContext.WriteIndentedLine("/// <summary>");
-        outputContext.WriteIndentedLine("/// " + Comment);
-        outputContext.WriteIndentedLine("/// </summary>");
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
 
         foreach (ParameterDefinition parameterDefinition in ParameterList)
         {
             if (parameterDefinition.Comment != null)
             {
-                outputContext.WriteIndentedLine("/// <param name=\"" + parameterDefinition.Name + "\">" + parameterDefinition.Comment + "</param>");
+                DocumentationComment.WriteElement(
+                    outputContext.WriteIndentedLine,
+                    "<param name=\"" + parameterDefinition.Name + "\">",
+                    "</param>",
+                    parameterDefinition.Comment);
             }
         }
-        
+
         if (ReturnComment != null)
         {
-            outputContext.WriteIndentedLine("/// <returns>" + ReturnComment + "</returns>");
+            DocumentationComment.WriteElement(
+                outputContext.WriteIndentedLine, "<returns>", "</returns>", ReturnComment);
         }
     }
 

--- a/CSharpAuthor/PropertyDefinition.cs
+++ b/CSharpAuthor/PropertyDefinition.cs
@@ -163,9 +163,7 @@ public class PropertyDefinition : BaseOutputComponent, INamedComponent
             return;
         }
         
-        outputContext.WriteIndentedLine($"/// <summary>");
-        outputContext.WriteIndentedLine($"/// {Comment}");
-        outputContext.WriteIndentedLine($"/// </summary>");
+        DocumentationComment.WriteSummary(outputContext.WriteIndentedLine, Comment);
     }
 
     protected virtual void WriteAccessModifiers(IOutputContext outputContext)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 1.1.1009
+  build_version: 1.1.1010
   Version: $(build_version)
 version: $(build_version)-{build}
 configuration: Release


### PR DESCRIPTION
Five fixes, four of which are the same defect at different levels: a component accepts a `Comment`, reads as documented at the call site, and emits nothing.

## What changed

**Base types can take constructor arguments.** `AddBaseType(type, params IOutputComponent[])`, which is what makes `record Dog(string Id, string Breed) : Pet(Id)` expressible. Previously `ClassDefinition` wrote base types as bare names with no argument list, so a derived positional record could not forward anything to its base.

**Comments may span lines.** All six `WriteComment` implementations went through one `"/// " + Comment`, so a line break emitted a continuation line with neither indent nor marker — output that does not compile. Now shared through `DocumentationComment`, which also opens `<param>`/`<returns>` onto their own lines when their content wraps.

**Enums write their comments.** `EnumDefinition` never overrode `WriteComment`.

**Enum members write their comments.** Nor did `EnumValueDefinition`.

**Records document their positional properties.** `ClassDefinition` wrote only `<summary>`, so a positional record could document itself but not the properties it declares in its header — which is the only place the C# compiler accepts `<param>` for them.

The last three share a root cause worth naming: `Comment` is inherited from `BaseOutputComponent` by every component, and the base `WriteComment` is empty. Any component that does not override it silently discards what it was given.

## Why now

These block work in `Hardened.Framework`, which consumes this library from a checkout while iterating. Against the published 1.1.1009 the enum, enum-member and record-property comments are dropped and multi-line prose does not compile; the base-type change is what lets its OpenAPI generator emit real record inheritance for `oneOf` + `discriminator` hierarchies.

## Version

`appveyor.yml` moves to **1.1.1010**. Note this release also carries #13's type-parameter-constraint work, which merged with `build_version` still at 1.1.1009 and so was never published.

## Testing

358 new lines of tests across `BaseTypeArgumentTests`, `DeclarationCommentTests` and `MultiLineCommentTests`. Full suite: **139 passed, 0 failed**, rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMveTF6J4oWhXfQCz5amPA