### PR TITLE
Cut 2.0.0-preview1001

### DIFF
--- a/CSharpAuthor/CSharpAuthor.csproj
+++ b/CSharpAuthor/CSharpAuthor.csproj
@@ -12,7 +12,7 @@
 			final. A release build overrides both from the tag.
 		-->
 		<VersionPrefix>2.0.0</VersionPrefix>
-		<VersionSuffix>preview1000</VersionSuffix>
+		<VersionSuffix>preview1001</VersionSuffix>
 		<Authors>Ian Johnson</Authors>
 		<PackageTags>source code generation</PackageTags>
 		<PackageProjectUrl>https://github.com/ipjohnson/CSharpAuthor</PackageProjectUrl>


### PR DESCRIPTION
Version bump only. The fixes themselves landed in #16.

`preview1000` shipped three silent defects on inline write paths:

| | Defect |
|---|---|
| A | `parameter.AddUsingNamespace` dropped |
| D | `parameterAttribute.AddUsingNamespace` dropped |
| C | call receiver written unescaped — `event` declared `@event`, invoked as `event.Go()` |

A and D share a cause: `BaseOutputComponent.WriteOutput` is the only place `UsingNamespaces` was read, and neither inline write path went through it. `UsingNamespaceRoutingTests` now ratchets the shape rather than the two instances.

The tag is what sets the published version; this bump keeps a local `dotnet pack` off main from producing something labelled `preview1000` that isn't.

Tagging `v2.0.0-preview1001` once this is on main.