### PR TITLE
Fix silent-wrongness defects and add the Roslyn symbol bridge

### DIFF
--- a/CSharpAuthor.Tests/CSharpAuthor.Tests.csproj
+++ b/CSharpAuthor.Tests/CSharpAuthor.Tests.csproj
@@ -19,4 +19,14 @@
     <ProjectReference Include="..\CSharpAuthor\CSharpAuthor.csproj" />
   </ItemGroup>
 
+  <!--
+    The Roslyn bridge ships as source rather than in the assembly, so this is the only way to
+    test it - and it compiles it the same way a consumer does: the sources linked in, against the
+    library referenced normally.
+  -->
+  <ItemGroup>
+    <Compile Include="..\CSharpAuthor\Roslyn\**\*.cs" LinkBase="RoslynBridge" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+
 </Project>

--- a/CSharpAuthor.Tests/CSharpFileDefinitionTests/AddRecordTests.cs
+++ b/CSharpAuthor.Tests/CSharpFileDefinitionTests/AddRecordTests.cs
@@ -31,7 +31,6 @@ public class AddRecordTests
 
 public sealed record Person
 {
-
     public string Name { get; init; } = default!;
 
     public int Age { get; init; }
@@ -58,7 +57,6 @@ public sealed record Person
 
 public record Item
 {
-
     public string Value { get; set; }
 }
 ";

--- a/CSharpAuthor.Tests/CSharpFileDefinitionTests/CSharpFileGenerationTests.cs
+++ b/CSharpAuthor.Tests/CSharpFileDefinitionTests/CSharpFileGenerationTests.cs
@@ -37,7 +37,6 @@ namespace TestNamespace
 {
     public class TestClass
     {
-
         public void SomeMethod()
         {
         }

--- a/CSharpAuthor.Tests/ClassDefinitionTests/ClassBodySpacingTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/ClassBodySpacingTests.cs
@@ -1,0 +1,73 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.ClassDefinitionTests;
+
+/// <summary>
+/// The blank line between members used to be written before each member rather than between them,
+/// which put one directly under the opening brace of every generated type.
+/// </summary>
+public class ClassBodySpacingTests
+{
+    [Fact]
+    public void FirstMemberFollowsTheOpeningBrace()
+    {
+        var classDefinition = new ClassDefinition("Holder");
+
+        classDefinition.AddMethod("First");
+        classDefinition.AddMethod("Second");
+
+        AssertEqual.WithoutNewLine(FirstMemberExpected, Write(classDefinition));
+    }
+
+    private const string FirstMemberExpected =
+        @"public class Holder
+{
+    public void First()
+    {
+    }
+
+    public void Second()
+    {
+    }
+}
+";
+
+    [Fact]
+    public void FieldsPackTogetherAndTheNextMemberIsSeparated()
+    {
+        var classDefinition = new ClassDefinition("Holder");
+
+        classDefinition.AddField(TypeDefinition.Get(typeof(string)), "_first");
+        classDefinition.AddField(TypeDefinition.Get(typeof(string)), "_second");
+        classDefinition.AddMethod("Work");
+
+        AssertEqual.WithoutNewLine(FieldsExpected, Write(classDefinition));
+    }
+
+    private const string FieldsExpected =
+        @"public class Holder
+{
+    private string _first;
+    private string _second;
+
+    public void Work()
+    {
+    }
+}
+";
+
+    [Fact]
+    public void EmptyClassHasNoBlankBody()
+    {
+        AssertEqual.WithoutNewLine("public class Holder\n{\n}\n", Write(new ClassDefinition("Holder")));
+    }
+
+    private static string Write(IOutputComponent component)
+    {
+        var context = new OutputContext();
+
+        component.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor.Tests/ClassDefinitionTests/EventDefinitionTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/EventDefinitionTests.cs
@@ -20,7 +20,6 @@ public class EventDefinitionTests
     private const string FieldLikeOutput =
         @"public class Publisher
 {
-
     public event EventHandler Changed;
 }
 ";
@@ -43,7 +42,6 @@ public class EventDefinitionTests
     private const string AccessorsOutput =
         @"public class Publisher
 {
-
     public event EventHandler Changed
     {
         add

--- a/CSharpAuthor.Tests/ClassDefinitionTests/GenericClassDefinitionTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/GenericClassDefinitionTests.cs
@@ -113,7 +113,6 @@ public class GenericClassDefinitionTests
     private const string ConstructorOutput =
         @"public class Box<T>
 {
-
     public Box(T value)
     {
         _value = value;
@@ -156,10 +155,8 @@ public class GenericClassDefinitionTests
     private const string NestedGenericOutput =
         @"public class Wrapper
 {
-
     private sealed class State<T> : InvocationState<T> where T : class
     {
-
         public override T Invoke()
         {
             return _inner.Pick<T>(_arg0);

--- a/CSharpAuthor.Tests/ClassDefinitionTests/SealedAndRecordTests.cs
+++ b/CSharpAuthor.Tests/ClassDefinitionTests/SealedAndRecordTests.cs
@@ -58,7 +58,6 @@ public class SealedAndRecordTests
     private const string SealedRecordOutput =
         @"public sealed record TestRecord
 {
-
     public string Name { get; set; }
 }
 ";

--- a/CSharpAuthor.Tests/CommentTests/ClassDefinitionCommentTests.cs
+++ b/CSharpAuthor.Tests/CommentTests/ClassDefinitionCommentTests.cs
@@ -36,7 +36,6 @@ public class ClassDefinitionCommentTests
 /// </summary>
 public class MyClass
 {
-
     /// <summary>
     /// This is an int property
     /// </summary>

--- a/CSharpAuthor.Tests/EquatableArrayTests.cs
+++ b/CSharpAuthor.Tests/EquatableArrayTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace CSharpAuthor.Tests;
+
+public class EquatableArrayTests
+{
+    private record Model(EquatableArray<string> Names);
+
+    private record ReferenceModel(IReadOnlyList<string> Names);
+
+    /// <summary>
+    /// The reason this type exists: a record holding an ordinary collection compares it by
+    /// reference, so an incremental generator's cache misses on every edit.
+    /// </summary>
+    [Fact]
+    public void RecordHoldingOneComparesByContents()
+    {
+        var first = new Model(EquatableArray.Create("a", "b"));
+        var second = new Model(EquatableArray.Create("a", "b"));
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+
+        // The behaviour being replaced.
+        Assert.NotEqual(
+            new ReferenceModel(new List<string> { "a", "b" }),
+            new ReferenceModel(new List<string> { "a", "b" }));
+    }
+
+    [Fact]
+    public void DifferentContentsAreNotEqual()
+    {
+        Assert.NotEqual(EquatableArray.Create("a", "b"), EquatableArray.Create("a", "c"));
+        Assert.NotEqual(EquatableArray.Create("a"), EquatableArray.Create("a", "b"));
+    }
+
+    [Fact]
+    public void OrderMatters()
+    {
+        Assert.NotEqual(EquatableArray.Create("a", "b"), EquatableArray.Create("b", "a"));
+    }
+
+    [Fact]
+    public void DefaultAndEmptyBehave()
+    {
+        var uninitialised = default(EquatableArray<string>);
+
+        Assert.Empty(uninitialised);
+        Assert.Equal(0, uninitialised.Count);
+        Assert.Equal(uninitialised, new EquatableArray<string>((string[]?)null));
+        Assert.Equal(EquatableArray<string>.Empty, EquatableArray.Create<string>());
+    }
+
+    /// <summary>
+    /// The type this library is mostly used to carry. It compares by value but implements
+    /// <c>IComparable</c> rather than <c>IEquatable</c>, which is why there is no constraint.
+    /// </summary>
+    [Fact]
+    public void HoldsTypeDefinitions()
+    {
+        var first = EquatableArray.Create<ITypeDefinition>(
+            TypeDefinition.Get("Sample", "Widget"),
+            TypeDefinition.Get(typeof(int)).MakeArray());
+
+        var second = EquatableArray.Create<ITypeDefinition>(
+            TypeDefinition.Get("Sample", "Widget"),
+            TypeDefinition.Get(typeof(int)).MakeArray());
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+
+        Assert.NotEqual(
+            first,
+            EquatableArray.Create<ITypeDefinition>(
+                TypeDefinition.Get("Sample", "Widget"),
+                TypeDefinition.Get(typeof(int)).MakeArray(2)));
+    }
+
+    [Fact]
+    public void EnumeratesAndIndexes()
+    {
+        var array = EquatableArray.Create("a", "b", "c");
+
+        Assert.Equal(3, array.Count);
+        Assert.Equal("b", array[1]);
+        Assert.Equal(new[] { "a", "b", "c" }, array.ToArray());
+        Assert.Equal("abc", string.Concat(array.ToList()));
+    }
+
+    [Fact]
+    public void BuildsFromAnySequence()
+    {
+        Assert.Equal(
+            EquatableArray.Create("a", "b"),
+            Enumerable.Range(0, 2).Select(i => i == 0 ? "a" : "b").ToEquatableArray());
+    }
+
+    [Fact]
+    public void OperatorsMatchEquals()
+    {
+        Assert.True(EquatableArray.Create("a") == EquatableArray.Create("a"));
+        Assert.True(EquatableArray.Create("a") != EquatableArray.Create("b"));
+    }
+}

--- a/CSharpAuthor.Tests/MethodTests/BlockFormattingTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/BlockFormattingTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace CSharpAuthor.Tests.MethodTests;
+
+public class BlockFormattingTests
+{
+    [Fact]
+    public void WhileKeepsTheSpaceBeforeItsCondition()
+    {
+        var method = new MethodDefinition("Test");
+
+        method.While(CodeOutputComponent.Get("keepGoing")).AddCode("i++;");
+
+        AssertEqual.ContainsWithoutNewLine("    while (keepGoing)\n", Write(method));
+    }
+
+    /// <summary>
+    /// The enclosing <c>while (</c> already writes the parentheses, the same as <c>if</c> does.
+    /// </summary>
+    [Fact]
+    public void WhileDoesNotDoubleTheParenthesesOfALogicStatement()
+    {
+        var method = new MethodDefinition("Test");
+
+        method.While(
+            SyntaxHelpers.And(CodeOutputComponent.Get("a"), CodeOutputComponent.Get("b")))
+            .AddCode("i++;");
+
+        AssertEqual.ContainsWithoutNewLine("    while (a && b)\n", Write(method));
+    }
+
+    /// <summary>
+    /// The loop variable's keyword used to be part of the literal <c>"foreach(var "</c>, so an
+    /// explicitly typed loop could not be expressed at all.
+    /// </summary>
+    [Fact]
+    public void ForEachCanDeclareAnExplicitType()
+    {
+        var method = new MethodDefinition("Test");
+
+        var items = method.AddParameter(typeof(IEnumerable<object>), "items");
+
+        method.ForEach(TypeDefinition.Get("Sample.Models", "Widget"), "item", items)
+            .AddCode("Use(item);");
+
+        var context = new OutputContext();
+
+        method.WriteOutput(context);
+        context.GenerateUsingStatements();
+
+        var output = context.Output();
+
+        AssertEqual.ContainsWithoutNewLine("    foreach (Widget item in items)\n", output);
+
+        // Passing the type also lets it reach import derivation.
+        AssertEqual.ContainsWithoutNewLine("using Sample.Models;", output);
+    }
+
+    [Fact]
+    public void ForEachStillDefaultsToVar()
+    {
+        var method = new MethodDefinition("Test");
+
+        var items = method.AddParameter(typeof(IEnumerable<object>), "items");
+
+        method.ForEach("item", items).AddCode("Use(item);");
+
+        AssertEqual.ContainsWithoutNewLine("    foreach (var item in items)\n", Write(method));
+    }
+
+    [Fact]
+    public void ObjectInitializerIsSpacedFromTheConstructorCall()
+    {
+        var method = new MethodDefinition("Test");
+
+        var statement = SyntaxHelpers.New(TypeDefinition.Get("Sample", "Profile"));
+
+        statement.AddInitValue(CodeOutputComponent.Get("Handle = h"));
+
+        method.Assign(statement).ToVar("profile");
+
+        AssertEqual.ContainsWithoutNewLine(
+            "    var profile = new Profile() { Handle = h };\n", Write(method));
+    }
+
+    private static string Write(IOutputComponent component)
+    {
+        var context = new OutputContext();
+
+        component.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor.Tests/MethodTests/MethodBlockTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/MethodBlockTests.cs
@@ -72,7 +72,7 @@ public class MethodBlockTests
     private const string ForEachExpected = 
         @"public void Test(IEnumerable<object> collection)
 {
-    foreach(var someValue in collection)
+    foreach (var someValue in collection)
     {
         var someField = someValue.ToString();
     }

--- a/CSharpAuthor.Tests/MethodTests/StatementPositionTests.cs
+++ b/CSharpAuthor.Tests/MethodTests/StatementPositionTests.cs
@@ -1,0 +1,73 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.MethodTests;
+
+/// <summary>
+/// An expression node writes no terminator, because it does not know it is being used as a
+/// statement. Adding one straight to a block emitted an unterminated line and the generated file
+/// did not compile.
+/// </summary>
+public class StatementPositionTests
+{
+    private static string Write(IOutputComponent component)
+    {
+        var context = new OutputContext();
+
+        component.WriteOutput(context);
+
+        return context.Output();
+    }
+
+    [Fact]
+    public void AddStatementIndentsAndTerminates()
+    {
+        var method = new MethodDefinition("Test");
+
+        method.AddStatement(new InvokeDefinition("writer", "WriteStartObject"));
+
+        AssertEqual.WithoutNewLine(
+            "public void Test()\n{\n    writer.WriteStartObject();\n}\n", Write(method));
+    }
+
+    /// <summary>
+    /// The wrapper writes the indent, so a component that would indent itself must not - otherwise
+    /// the line is indented twice.
+    /// </summary>
+    [Fact]
+    public void AddStatementDoesNotDoubleTheIndent()
+    {
+        var method = new MethodDefinition("Test");
+
+        var forEach = method.ForEach("item", CodeOutputComponent.Get("items"));
+
+        forEach.AddStatement(new InvokeDefinition("writer", "Write", CodeOutputComponent.Get("item")));
+
+        AssertEqual.ContainsWithoutNewLine("        writer.Write(item);\n", Write(method));
+    }
+
+    [Fact]
+    public void AddStatementReturnsTheComponentTyped()
+    {
+        var method = new MethodDefinition("Test");
+
+        InvokeDefinition invoke = method.AddStatement(new InvokeDefinition("writer", "Flush"));
+
+        Assert.NotNull(invoke);
+    }
+
+    /// <summary>
+    /// Composes with the Invoke extension, so a call built as an expression can be placed as a
+    /// statement without being rebuilt.
+    /// </summary>
+    [Fact]
+    public void ComposesWithTheInvokeExtension()
+    {
+        var method = new MethodDefinition("Test");
+
+        var writer = method.AddParameter(TypeDefinition.Get("System.Text.Json", "Utf8JsonWriter"), "writer");
+
+        method.AddStatement(writer.Invoke("WriteEndObject"));
+
+        AssertEqual.ContainsWithoutNewLine("    writer.WriteEndObject();\n", Write(method));
+    }
+}

--- a/CSharpAuthor.Tests/NamespaceTests/FileScopedNamespaceTests.cs
+++ b/CSharpAuthor.Tests/NamespaceTests/FileScopedNamespaceTests.cs
@@ -24,7 +24,6 @@ public class FileScopedNamespaceTests
 
 public class TestClass
 {
-
     public void DoWork()
     {
     }

--- a/CSharpAuthor.Tests/OutputContextTests/NewLineOptionTests.cs
+++ b/CSharpAuthor.Tests/OutputContextTests/NewLineOptionTests.cs
@@ -1,0 +1,75 @@
+using System;
+using Xunit;
+
+namespace CSharpAuthor.Tests.OutputContextTests;
+
+/// <summary>
+/// <see cref="OutputContextOptions.NewLine"/> used to reach only the parameterless
+/// <c>WriteLine()</c> and the using block. Everything else went through
+/// <c>StringBuilder.AppendLine</c>, which appends <see cref="Environment.NewLine"/> - so the
+/// setting was ignored and generated output varied with the operating system it was generated on.
+/// </summary>
+public class NewLineOptionTests
+{
+    [Theory]
+    [InlineData("\r\n")]
+    [InlineData("\n")]
+    public void EveryLineEndsWithTheConfiguredNewLine(string newLine)
+    {
+        var method = new MethodDefinition("Boom");
+
+        method.SetReturnType(TypeDefinition.Get(typeof(int)));
+        method.Throw(typeof(Exception), SyntaxHelpers.QuoteString("bad"));
+        method.Return(1);
+
+        var context = new OutputContext(new OutputContextOptions { NewLine = newLine });
+
+        method.WriteOutput(context);
+
+        var expected =
+            "public int Boom()" + newLine +
+            "{" + newLine +
+            "    throw new Exception(\"bad\");" + newLine +
+            "    return 1;" + newLine +
+            "}" + newLine;
+
+        Assert.Equal(expected, context.Output());
+    }
+
+    /// <summary>
+    /// A file, rather than a single member - the using block, namespace and class body each write
+    /// their own line breaks.
+    /// </summary>
+    [Fact]
+    public void FileOutputCarriesNoForeignLineEndings()
+    {
+        var file = new CSharpFileDefinition("Sample");
+        var classDefinition = file.AddClass("Holder");
+
+        classDefinition.AddField(TypeDefinition.Get(typeof(string)), "_name");
+        classDefinition.AddMethod("Work").AddCode("Run();");
+        classDefinition.AddUsingNamespace("System.Text");
+
+        var context = new OutputContext(new OutputContextOptions { NewLine = "\r\n" });
+
+        file.WriteOutput(context);
+
+        var output = context.Output();
+
+        Assert.DoesNotContain("\n", output.Replace("\r\n", ""));
+    }
+
+    [Fact]
+    public void ThrowIsTerminatedLikeEveryOtherStatement()
+    {
+        var method = new MethodDefinition("Boom");
+
+        method.Throw(TypeDefinition.Get(typeof(Exception)));
+
+        var context = new OutputContext(new OutputContextOptions { NewLine = "\r\n" });
+
+        method.WriteOutput(context);
+
+        Assert.Contains("    throw new Exception();\r\n", context.Output());
+    }
+}

--- a/CSharpAuthor.Tests/OutputContextTests/UsingStatementTests.cs
+++ b/CSharpAuthor.Tests/OutputContextTests/UsingStatementTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.OutputContextTests;
+
+public class UsingStatementTests
+{
+    /// <summary>
+    /// <see cref="CSharpFileDefinition"/> already generates them, and nothing at the call site
+    /// says so - so calling it again used to emit the whole block twice.
+    /// </summary>
+    [Fact]
+    public void GeneratingTwiceDoesNotDuplicateTheBlock()
+    {
+        var file = new CSharpFileDefinition("Sample");
+
+        file.AddClass("Holder").AddMethod("Work")
+            .SetReturnType(TypeDefinition.Get("System.Text", "StringBuilder"));
+
+        var context = new OutputContext();
+
+        file.WriteOutput(context);
+        context.GenerateUsingStatements();
+        context.GenerateUsingStatements();
+
+        var output = context.Output();
+
+        Assert.Equal(1, output.Split(new[] { "using System.Text;" }, System.StringSplitOptions.None).Length - 1);
+    }
+}

--- a/CSharpAuthor.Tests/PropertyDefinitionTests/IndexerPropertyTests.cs
+++ b/CSharpAuthor.Tests/PropertyDefinitionTests/IndexerPropertyTests.cs
@@ -23,7 +23,6 @@ public class IndexerPropertyTests
     private const string SingleIndexOutput =
         @"public class Row
 {
-
     public string this[int index]
     {
         get
@@ -58,7 +57,6 @@ public class IndexerPropertyTests
     private const string SeveralIndicesOutput =
         @"public class Grid
 {
-
     public int this[int row, int column]
     {
         get
@@ -95,7 +93,6 @@ public class IndexerPropertyTests
     private const string ReadOnlyOutput =
         @"public class Row
 {
-
     public string this[int index]
     {
         get

--- a/CSharpAuthor.Tests/RoslynTests/SymbolBridgeTests.cs
+++ b/CSharpAuthor.Tests/RoslynTests/SymbolBridgeTests.cs
@@ -1,0 +1,267 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CSharpAuthor.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace CSharpAuthor.Tests.RoslynTests;
+
+/// <summary>
+/// Driven from real compiled source rather than hand-built symbols, because the cases that used to
+/// be got wrong - nested types, <c>Nullable&lt;T&gt;</c>, jagged and multidimensional arrays - are
+/// exactly the ones where a hand-built symbol would encode the assumption being tested.
+/// </summary>
+public class SymbolBridgeTests
+{
+    private const string Source = @"
+using System;
+using System.Collections.Generic;
+
+namespace Sample.Models
+{
+    public class Outer
+    {
+        public class Inner { }
+    }
+
+    public class OuterGeneric<T>
+    {
+        public class Inner { }
+    }
+
+    public interface IMarker { }
+
+    public enum Colour { Red }
+
+    public struct Point { }
+
+    public class Holder<TValue>
+    {
+        public int Number { get; set; }
+        public float Ratio { get; set; }
+        public char Letter { get; set; }
+        public sbyte Small { get; set; }
+        public IntPtr Native { get; set; }
+        public int? MaybeNumber { get; set; }
+        public string Text { get; set; }
+        public string? MaybeText { get; set; }
+        public string[] Names { get; set; }
+        public string[][] Jagged { get; set; }
+        public int[,] Grid { get; set; }
+        public int[][,] Mixed { get; set; }
+        public Dictionary<string, int> Map { get; set; }
+        public Outer.Inner Nested { get; set; }
+        public OuterGeneric<string>.Inner NestedInGeneric { get; set; }
+        public IMarker Marker { get; set; }
+        public Colour Shade { get; set; }
+        public Point Location { get; set; }
+        public TValue Value { get; set; }
+        public TValue[] Values { get; set; }
+        public List<Outer.Inner> NestedList { get; set; }
+        public void Go(ref int counter) { }
+    }
+}";
+
+    private static readonly INamedTypeSymbol _holder = CompileHolder();
+
+    private static INamedTypeSymbol CompileHolder()
+    {
+        var compilation = CSharpCompilation.Create(
+            "SymbolBridgeTests",
+            new[] { CSharpSyntaxTree.ParseText(Source) },
+            new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        // A bridge fed error symbols would be testing the wrong thing.
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        Assert.Empty(errors);
+
+        return compilation.GetTypeByMetadataName("Sample.Models.Holder`1")!;
+    }
+
+    private static string Render(string propertyName, TypeOutputMode mode = TypeOutputMode.ShortName)
+    {
+        var property = (IPropertySymbol)_holder.GetMembers(propertyName).Single();
+
+        var builder = new System.Text.StringBuilder();
+
+        property.GetTypeDefinition().WriteTypeName(builder, mode);
+
+        return builder.ToString();
+    }
+
+    [Theory]
+    [InlineData("Number", "int")]
+    [InlineData("Ratio", "float")]
+    [InlineData("Letter", "char")]
+    [InlineData("Small", "sbyte")]
+    [InlineData("Text", "string")]
+    public void FrameworkTypesBecomeKeywords(string property, string expected)
+    {
+        Assert.Equal(expected, Render(property));
+    }
+
+    /// <summary>
+    /// C# 9, so it stays as the framework name until a target version reaches rendering.
+    /// </summary>
+    [Fact]
+    public void NativeIntegerKeepsItsFrameworkName()
+    {
+        Assert.Equal("IntPtr", Render("Native"));
+    }
+
+    [Fact]
+    public void NullableValueTypeUsesTheShorthand()
+    {
+        Assert.Equal("int?", Render("MaybeNumber"));
+    }
+
+    [Fact]
+    public void NullableReferenceAnnotationIsCarried()
+    {
+        Assert.Equal("string?", Render("MaybeText"));
+        Assert.Equal("string", Render("Text"));
+    }
+
+    [Theory]
+    [InlineData("Names", "string[]")]
+    [InlineData("Jagged", "string[][]")]
+    [InlineData("Grid", "int[,]")]
+    [InlineData("Mixed", "int[,][]")]
+    public void ArraysKeepRankAndNesting(string property, string expected)
+    {
+        Assert.Equal(expected, Render(property));
+    }
+
+    [Fact]
+    public void GenericsCarryTheirArguments()
+    {
+        Assert.Equal("Dictionary<string, int>", Render("Map"));
+    }
+
+    /// <summary>
+    /// Without the container, <c>Inner</c> binds to whatever <c>Inner</c> is in scope at the point
+    /// of use - or to nothing.
+    /// </summary>
+    [Fact]
+    public void NestedTypesKeepTheirContainer()
+    {
+        Assert.Equal("Outer.Inner", Render("Nested"));
+        Assert.Equal("global::Sample.Models.Outer.Inner", Render("Nested", TypeOutputMode.Global));
+    }
+
+    [Fact]
+    public void NestedInsideAGenericContainerKeepsItsArguments()
+    {
+        Assert.Equal("OuterGeneric<string>.Inner", Render("NestedInGeneric"));
+    }
+
+    [Fact]
+    public void NestedTypeInsideAGenericArgumentStillQualifies()
+    {
+        Assert.Equal("List<Outer.Inner>", Render("NestedList"));
+    }
+
+    [Fact]
+    public void TypeKindIsCarried()
+    {
+        var marker = (IPropertySymbol)_holder.GetMembers("Marker").Single();
+        var shade = (IPropertySymbol)_holder.GetMembers("Shade").Single();
+        var location = (IPropertySymbol)_holder.GetMembers("Location").Single();
+
+        Assert.Equal(TypeDefinitionEnum.InterfaceDefinition, marker.GetTypeDefinition().TypeDefinitionEnum);
+        Assert.Equal(TypeDefinitionEnum.EnumDefinition, shade.GetTypeDefinition().TypeDefinitionEnum);
+        Assert.Equal(TypeDefinitionEnum.ClassDefinition, location.GetTypeDefinition().TypeDefinitionEnum);
+    }
+
+    /// <summary>
+    /// A type parameter names nothing outside its declaration, so it is never qualified and
+    /// contributes no namespace.
+    /// </summary>
+    [Fact]
+    public void TypeParametersAreWrittenAsThemselves()
+    {
+        Assert.Equal("TValue", Render("Value", TypeOutputMode.Global));
+        Assert.Equal("TValue[]", Render("Values"));
+
+        var value = (IPropertySymbol)_holder.GetMembers("Value").Single();
+
+        Assert.Empty(value.GetTypeDefinition().KnownNamespaces.Where(ns => !string.IsNullOrEmpty(ns)));
+    }
+
+    [Fact]
+    public void ParameterAndReturnTypesConvert()
+    {
+        var method = (IMethodSymbol)_holder.GetMembers("Go").Single();
+
+        Assert.Equal("void", method.GetReturnTypeDefinition().GetShortName());
+        Assert.Equal("int", method.Parameters[0].GetTypeDefinition().GetShortName());
+    }
+
+    /// <summary>
+    /// The whole point of converting rather than stringifying: the type stays unrendered, so the
+    /// output context still derives the imports.
+    /// </summary>
+    [Fact]
+    public void ConvertedTypesStillDeriveImports()
+    {
+        var property = (IPropertySymbol)_holder.GetMembers("Map").Single();
+
+        var context = new OutputContext();
+
+        context.Write(property.GetTypeDefinition());
+        context.GenerateUsingStatements();
+
+        Assert.Equal("using System.Collections.Generic;\n\nDictionary<string, int>", context.Output());
+    }
+
+    [Fact]
+    public void KeywordsAndTypeParametersImportNothing()
+    {
+        var context = new OutputContext();
+
+        context.Write(((IPropertySymbol)_holder.GetMembers("Number").Single()).GetTypeDefinition());
+        context.Write(((IPropertySymbol)_holder.GetMembers("Value").Single()).GetTypeDefinition());
+        context.GenerateUsingStatements();
+
+        Assert.Equal("intTValue", context.Output());
+    }
+
+    [Fact]
+    public void UnboundGenericBecomesAnOpenType()
+    {
+        var map = (IPropertySymbol)_holder.GetMembers("Map").Single();
+        var unbound = ((INamedTypeSymbol)map.Type).ConstructUnboundGenericType();
+
+        Assert.Equal("Dictionary<,>", unbound.GetTypeDefinition().GetShortName());
+    }
+
+    [Fact]
+    public void GlobalNamespaceIsEmptyRatherThanItsDisplayString()
+    {
+        Assert.Equal("Sample.Models", _holder.GetNamespace());
+        Assert.Equal("", _holder.ContainingNamespace.ContainingNamespace.ContainingNamespace.GetNamespace());
+    }
+
+    /// <summary>
+    /// A pointer has no representation in the type model, so it says so rather than quietly
+    /// producing the pointed-to type.
+    /// </summary>
+    [Fact]
+    public void PointersAreRefusedRatherThanApproximated()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Pointers",
+            new[] { CSharpSyntaxTree.ParseText("public unsafe class P { public int* Value; }") },
+            new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+        var field = (IFieldSymbol)compilation.GetTypeByMetadataName("P")!.GetMembers("Value").Single();
+
+        Assert.Throws<System.NotSupportedException>(() => field.GetTypeDefinition());
+    }
+}

--- a/CSharpAuthor.Tests/SyntaxTests/ExpressionFormTests.cs
+++ b/CSharpAuthor.Tests/SyntaxTests/ExpressionFormTests.cs
@@ -1,0 +1,115 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.SyntaxTests;
+
+/// <summary>
+/// The forms a real generator reached for and had to write as raw strings, because there was no
+/// node for them. A raw string carries no type reference, so every one of these escapes also opted
+/// its fragment out of import derivation.
+/// </summary>
+public class ExpressionFormTests
+{
+    private static string Write(IOutputComponent component)
+    {
+        var context = new OutputContext();
+
+        component.WriteOutput(context);
+
+        return context.Output();
+    }
+
+    [Fact]
+    public void MemberAccess()
+    {
+        Assert.Equal("target.Handle", Write(SyntaxHelpers.MemberAccess(CodeOutputComponent.Get("target"), "Handle")));
+    }
+
+    [Fact]
+    public void NullTests()
+    {
+        Assert.Equal("value is null", Write(SyntaxHelpers.IsNull(CodeOutputComponent.Get("value"))));
+        Assert.Equal("value is not null", Write(SyntaxHelpers.IsNotNull(CodeOutputComponent.Get("value"))));
+    }
+
+    [Fact]
+    public void ArgumentModifiers()
+    {
+        Assert.Equal("ref reader", Write(SyntaxHelpers.Ref(CodeOutputComponent.Get("reader"))));
+        Assert.Equal("out result", Write(SyntaxHelpers.Out(CodeOutputComponent.Get("result"))));
+        Assert.Equal("in options", Write(SyntaxHelpers.In(CodeOutputComponent.Get("options"))));
+    }
+
+    [Fact]
+    public void OutVariableDeclaration()
+    {
+        Assert.Equal("out var value", Write(SyntaxHelpers.OutVar("value")));
+        Assert.Equal("out Widget value", Write(SyntaxHelpers.OutVar("value", TypeDefinition.Get("Sample", "Widget"))));
+    }
+
+    /// <summary>
+    /// The declared type reaches import derivation, which is the whole reason not to write it as a
+    /// string.
+    /// </summary>
+    [Fact]
+    public void OutVariableTypeIsImported()
+    {
+        var context = new OutputContext();
+
+        SyntaxHelpers.OutVar("value", TypeDefinition.Get("Sample.Models", "Widget")).WriteOutput(context);
+        context.GenerateUsingStatements();
+
+        Assert.Equal("using Sample.Models;\n\nout Widget value", context.Output());
+    }
+
+    [Fact]
+    public void NameOf()
+    {
+        Assert.Equal("nameof(target)", Write(SyntaxHelpers.NameOf(CodeOutputComponent.Get("target"))));
+        Assert.Equal("nameof(Widget)", Write(SyntaxHelpers.NameOf(TypeDefinition.Get("Sample", "Widget"))));
+    }
+
+    [Fact]
+    public void Conditional()
+    {
+        Assert.Equal(
+            "(hasValue ? value : fallback)",
+            Write(SyntaxHelpers.Conditional(
+                CodeOutputComponent.Get("hasValue"),
+                CodeOutputComponent.Get("value"),
+                CodeOutputComponent.Get("fallback"))));
+    }
+
+    [Fact]
+    public void ConditionalDropsItsParenthesesOnRequest()
+    {
+        var conditional = SyntaxHelpers.Conditional(
+            CodeOutputComponent.Get("hasValue"),
+            CodeOutputComponent.Get("value"),
+            CodeOutputComponent.Get("fallback"));
+
+        conditional.PrintParentheses = false;
+
+        Assert.Equal("hasValue ? value : fallback", Write(conditional));
+    }
+
+    /// <summary>
+    /// The condition sits inside the operator's own brackets, so it does not add its own.
+    /// </summary>
+    [Fact]
+    public void ConditionalDoesNotDoubleTheConditionsParentheses()
+    {
+        Assert.Equal(
+            "(a && b ? value : fallback)",
+            Write(SyntaxHelpers.Conditional(
+                SyntaxHelpers.And(CodeOutputComponent.Get("a"), CodeOutputComponent.Get("b")),
+                CodeOutputComponent.Get("value"),
+                CodeOutputComponent.Get("fallback"))));
+    }
+
+    [Fact]
+    public void Default()
+    {
+        Assert.Equal("default", Write(SyntaxHelpers.Default()));
+        Assert.Equal("default(Widget)", Write(SyntaxHelpers.Default(TypeDefinition.Get("Sample", "Widget"))));
+    }
+}

--- a/CSharpAuthor.Tests/SyntaxTests/NegationTests.cs
+++ b/CSharpAuthor.Tests/SyntaxTests/NegationTests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.SyntaxTests;
+
+public class NegationTests
+{
+    [Fact]
+    public void NotWritesThePrefixOperator()
+    {
+        Assert.Equal("!flag", Write(SyntaxHelpers.Not(CodeOutputComponent.Get("flag"))));
+    }
+
+    /// <summary>
+    /// <c>Bang</c> is the null-forgiving operator. Both forms are legal in a condition under
+    /// <c>#nullable enable</c>, so nothing but this test distinguishes them.
+    /// </summary>
+    [Fact]
+    public void BangWritesThePostfixOperator()
+    {
+        Assert.Equal("flag!", Write(SyntaxHelpers.Bang(CodeOutputComponent.Get("flag"))));
+    }
+
+    [Fact]
+    public void NegatingALogicStatementKeepsItsParentheses()
+    {
+        var statement = SyntaxHelpers.Not(
+            SyntaxHelpers.And(CodeOutputComponent.Get("a"), CodeOutputComponent.Get("b")));
+
+        Assert.Equal("!(a && b)", Write(statement));
+    }
+
+    private static string Write(IOutputComponent component)
+    {
+        var context = new OutputContext();
+
+        component.WriteOutput(context);
+
+        return context.Output();
+    }
+}

--- a/CSharpAuthor.Tests/SyntaxTests/QuoteStringTests.cs
+++ b/CSharpAuthor.Tests/SyntaxTests/QuoteStringTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace CSharpAuthor.Tests.SyntaxTests;
+
+public class QuoteStringTests
+{
+    [Theory]
+    [InlineData("plain", "\"plain\"")]
+    [InlineData("say \"hi\"", "\"say \\\"hi\\\"\"")]
+    [InlineData("C:\\path", "\"C:\\\\path\"")]
+    [InlineData("line\nbreak", "\"line\\nbreak\"")]
+    [InlineData("carriage\rreturn", "\"carriage\\rreturn\"")]
+    [InlineData("tab\there", "\"tab\\there\"")]
+    [InlineData("null\0char", "\"null\\0char\"")]
+    [InlineData("", "\"\"")]
+    [InlineData(null, "\"\"")]
+    public void EscapesWhatWouldCloseTheLiteral(string? value, string expected)
+    {
+        Assert.Equal(expected, SyntaxHelpers.QuoteString(value));
+    }
+
+    /// <summary>
+    /// The C# lexer treats these as line terminators, so they end a literal just as <c>\n</c> does
+    /// even though they are neither control characters nor quotes.
+    /// </summary>
+    [Theory]
+    [InlineData('\u0085', "\"\\u0085\"")]
+    [InlineData('\u2028', "\"\\u2028\"")]
+    [InlineData('\u2029', "\"\\u2029\"")]
+    [InlineData('\u0001', "\"\\u0001\"")]
+    public void EscapesCharactersWithNoShortForm(char value, string expected)
+    {
+        Assert.Equal(expected, SyntaxHelpers.QuoteString(value.ToString()));
+    }
+
+    [Fact]
+    public void LeavesOrdinaryUnicodeAlone()
+    {
+        Assert.Equal("\"café ☕\"", SyntaxHelpers.QuoteString("café ☕"));
+    }
+
+    /// <summary>
+    /// The <c>{argN}</c> substitution builds a literal of its own, and used to do it with quoting
+    /// inlined rather than by calling <see cref="SyntaxHelpers.QuoteString"/> - so it escaped
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void AddCodeSubstitutionEscapesToo()
+    {
+        var method = new MethodDefinition("Test");
+
+        method.AddCode("var name = {arg1};", "say \"hi\"");
+
+        var context = new OutputContext();
+
+        method.WriteOutput(context);
+
+        AssertEqual.ContainsWithoutNewLine("var name = \"say \\\"hi\\\"\";", context.Output());
+    }
+}

--- a/CSharpAuthor.Tests/TypeDefinitionTests/ArrayTypeTests.cs
+++ b/CSharpAuthor.Tests/TypeDefinitionTests/ArrayTypeTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace CSharpAuthor.Tests.TypeDefinitionTests;
+
+public class ArrayTypeTests
+{
+    private static string Write(ITypeDefinition type, TypeOutputMode mode = TypeOutputMode.ShortName)
+    {
+        var builder = new System.Text.StringBuilder();
+
+        type.WriteTypeName(builder, mode);
+
+        return builder.ToString();
+    }
+
+    [Fact]
+    public void SingleDimension()
+    {
+        Assert.Equal("string[]", Write(TypeDefinition.Get(typeof(string)).MakeArray()));
+    }
+
+    /// <summary>
+    /// Array-ness was a single bool carried by the element, so the second call returned a copy
+    /// that was already an array and the rank was silently dropped.
+    /// </summary>
+    [Fact]
+    public void JaggedArrayNests()
+    {
+        Assert.Equal("string[][]", Write(TypeDefinition.Get(typeof(string)).MakeArray().MakeArray()));
+    }
+
+    [Fact]
+    public void MultidimensionalArrayHasRank()
+    {
+        Assert.Equal("int[,]", Write(TypeDefinition.Get(typeof(int)).MakeArray(2)));
+        Assert.Equal("int[,,]", Write(TypeDefinition.Get(typeof(int)).MakeArray(3)));
+    }
+
+    [Theory]
+    [InlineData(typeof(int[]), "int[]")]
+    [InlineData(typeof(int[][]), "int[][]")]
+    [InlineData(typeof(int[,]), "int[,]")]
+    [InlineData(typeof(int[,,]), "int[,,]")]
+    [InlineData(typeof(int[][,]), "int[,][]")]
+    [InlineData(typeof(string[]), "string[]")]
+    public void ReflectedArraysRoundTrip(System.Type type, string expected)
+    {
+        Assert.Equal(expected, Write(TypeDefinition.Get(type)));
+    }
+
+    [Fact]
+    public void ArrayOfGenericKeepsTheElementsNamespaces()
+    {
+        var listOfString = new GenericTypeDefinition(
+            TypeDefinitionEnum.ClassDefinition,
+            "System.Collections.Generic",
+            "List",
+            new List<ITypeDefinition> { TypeDefinition.Get(typeof(string)) });
+
+        var context = new OutputContext();
+
+        context.Write(listOfString.MakeArray());
+        context.GenerateUsingStatements();
+
+        Assert.Equal("using System.Collections.Generic;\n\nList<string>[]", context.Output());
+    }
+
+    [Fact]
+    public void ArrayQualifiesItsElementInGlobalMode()
+    {
+        var type = TypeDefinition.Get("Sample.Models", "Widget").MakeArray().MakeArray();
+
+        Assert.Equal("global::Sample.Models.Widget[][]", Write(type, TypeOutputMode.Global));
+    }
+
+    [Fact]
+    public void NullableArrayIsDistinctFromArrayOfNullable()
+    {
+        var element = TypeDefinition.Get("Sample", "Widget");
+
+        Assert.Equal("Widget[]?", Write(element.MakeArray().MakeNullable()));
+        Assert.Equal("Widget?[]", Write(element.MakeNullable().MakeArray()));
+    }
+
+    [Fact]
+    public void ElementTypeUnwrapsOneLevel()
+    {
+        var jagged = TypeDefinition.Get(typeof(int)).MakeArray().MakeArray();
+
+        Assert.Equal("int[]", Write(jagged.GetElementType()!));
+        Assert.Null(TypeDefinition.Get(typeof(int)).GetElementType());
+    }
+
+    [Fact]
+    public void ArraysOfDifferentRankAreNotEqual()
+    {
+        var element = TypeDefinition.Get(typeof(int));
+
+        Assert.Equal(element.MakeArray(), element.MakeArray());
+        Assert.NotEqual(element.MakeArray(), element.MakeArray(2));
+        Assert.NotEqual(element.MakeArray(), element.MakeArray().MakeArray());
+    }
+}

--- a/CSharpAuthor.Tests/TypeDefinitionTests/GenericTypeArgumentTests.cs
+++ b/CSharpAuthor.Tests/TypeDefinitionTests/GenericTypeArgumentTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace CSharpAuthor.Tests.TypeDefinitionTests;
+
+public class GenericTypeArgumentTests
+{
+    private static GenericTypeDefinition Dictionary() =>
+        new(
+            TypeDefinitionEnum.ClassDefinition,
+            "System.Collections.Generic",
+            "Dictionary",
+            new List<ITypeDefinition>
+            {
+                TypeDefinition.Get(typeof(string)),
+                TypeDefinition.Get(typeof(int))
+            });
+
+    [Fact]
+    public void TypeArgumentsAreSeparatedByCommaSpace()
+    {
+        var context = new OutputContext();
+
+        context.Write(Dictionary());
+
+        Assert.Equal("Dictionary<string, int>", context.Output());
+    }
+
+    /// <summary>
+    /// Openness used to be faked with blank type arguments, each of which still wrote the <c>.</c>
+    /// joining its namespace to its name - so an open type rendered as
+    /// <c>Dictionary&lt;.,.&gt;</c>.
+    /// </summary>
+    [Fact]
+    public void OpenTypeWritesCommasWithoutArguments()
+    {
+        var context = new OutputContext();
+
+        context.Write(Dictionary().MakeOpenType());
+
+        Assert.Equal("Dictionary<,>", context.Output());
+    }
+
+    [Fact]
+    public void OpenTypeImportsOnlyItsOwnNamespace()
+    {
+        var context = new OutputContext();
+
+        context.Write(Dictionary().MakeOpenType());
+        context.GenerateUsingStatements();
+
+        Assert.Equal("using System.Collections.Generic;\n\nDictionary<,>", context.Output());
+    }
+
+    [Fact]
+    public void OpenTypeSurvivesBeingMadeNullable()
+    {
+        var context = new OutputContext();
+
+        context.Write(Dictionary().MakeOpenType().MakeNullable());
+
+        Assert.Equal("Dictionary<,>?", context.Output());
+    }
+}

--- a/CSharpAuthor.Tests/TypeDefinitionTests/NestedTypeTests.cs
+++ b/CSharpAuthor.Tests/TypeDefinitionTests/NestedTypeTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace CSharpAuthor.Tests.TypeDefinitionTests;
+
+/// <summary>
+/// A nested type used to be indistinguishable from a top-level one, so it wrote <c>Inner</c> alone
+/// and bound to whatever <c>Inner</c> was in scope where it was used.
+/// </summary>
+public class NestedTypeTests
+{
+    private class Outer
+    {
+        internal class Inner
+        {
+        }
+    }
+
+    private static string Write(ITypeDefinition type, TypeOutputMode mode = TypeOutputMode.ShortName)
+    {
+        var builder = new System.Text.StringBuilder();
+
+        type.WriteTypeName(builder, mode);
+
+        return builder.ToString();
+    }
+
+    [Fact]
+    public void NestedTypeCarriesItsContainer()
+    {
+        var outer = TypeDefinition.Get("Sample.Models", "Outer");
+        var inner = TypeDefinition.GetNested(outer, "Inner");
+
+        Assert.Equal("Outer.Inner", Write(inner));
+    }
+
+    [Fact]
+    public void ContainerIsQualifiedByTheOutputMode()
+    {
+        var outer = TypeDefinition.Get("Sample.Models", "Outer");
+        var inner = TypeDefinition.GetNested(outer, "Inner");
+
+        Assert.Equal("global::Sample.Models.Outer.Inner", Write(inner, TypeOutputMode.Global));
+        Assert.Equal("Sample.Models.Outer.Inner", Write(inner, TypeOutputMode.FullName));
+    }
+
+    /// <summary>
+    /// The container renders its own type arguments, which a dotted name could not have carried.
+    /// </summary>
+    [Fact]
+    public void GenericContainerWritesItsTypeArguments()
+    {
+        var outer = new GenericTypeDefinition(
+            TypeDefinitionEnum.ClassDefinition,
+            "Sample.Models",
+            "Outer",
+            new List<ITypeDefinition> { TypeDefinition.Get(typeof(string)) });
+
+        var inner = TypeDefinition.GetNested(outer, "Inner");
+
+        Assert.Equal("Outer<string>.Inner", Write(inner));
+    }
+
+    /// <summary>
+    /// Every level, not just the innermost - <c>Outer</c> is itself nested in this test class.
+    /// </summary>
+    [Fact]
+    public void ReflectedNestedTypeKeepsItsWholeContainerChain()
+    {
+        Assert.Equal("NestedTypeTests.Outer.Inner", Write(TypeDefinition.Get(typeof(Outer.Inner))));
+
+        Assert.Equal(
+            "global::CSharpAuthor.Tests.TypeDefinitionTests.NestedTypeTests.Outer.Inner",
+            Write(TypeDefinition.Get(typeof(Outer.Inner)), TypeOutputMode.Global));
+    }
+
+    [Fact]
+    public void NestedTypeImportsTheContainersNamespace()
+    {
+        var outer = TypeDefinition.Get("Sample.Models", "Outer");
+        var context = new OutputContext();
+
+        context.Write(TypeDefinition.GetNested(outer, "Inner"));
+        context.GenerateUsingStatements();
+
+        Assert.Equal("using Sample.Models;\n\nOuter.Inner", context.Output());
+    }
+
+    [Fact]
+    public void SameNameInDifferentContainersAreDifferentTypes()
+    {
+        var first = TypeDefinition.GetNested(TypeDefinition.Get("Sample", "First"), "Inner");
+        var second = TypeDefinition.GetNested(TypeDefinition.Get("Sample", "Second"), "Inner");
+
+        Assert.NotEqual(first, second);
+        Assert.NotEqual(0, first.CompareTo(second));
+    }
+
+    [Fact]
+    public void ArrayOfNestedTypeKeepsTheContainer()
+    {
+        var inner = TypeDefinition.GetNested(TypeDefinition.Get("Sample", "Outer"), "Inner");
+
+        Assert.Equal("Outer.Inner[]", Write(inner.MakeArray()));
+    }
+}

--- a/CSharpAuthor.Tests/TypeDefinitionTests/SpecialTypeTests.cs
+++ b/CSharpAuthor.Tests/TypeDefinitionTests/SpecialTypeTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Xunit;
+
+namespace CSharpAuthor.Tests.TypeDefinitionTests;
+
+public class SpecialTypeTests
+{
+    private static string Write(ITypeDefinition type)
+    {
+        var builder = new System.Text.StringBuilder();
+
+        type.WriteTypeName(builder);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The keyword table used to omit these, so they reached generated output as
+    /// <c>Single</c>, <c>Char</c> and <c>SByte</c>.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(float), "float")]
+    [InlineData(typeof(char), "char")]
+    [InlineData(typeof(sbyte), "sbyte")]
+    [InlineData(typeof(void), "void")]
+    [InlineData(typeof(int), "int")]
+    [InlineData(typeof(uint), "uint")]
+    [InlineData(typeof(short), "short")]
+    [InlineData(typeof(ushort), "ushort")]
+    [InlineData(typeof(long), "long")]
+    [InlineData(typeof(ulong), "ulong")]
+    [InlineData(typeof(byte), "byte")]
+    [InlineData(typeof(double), "double")]
+    [InlineData(typeof(decimal), "decimal")]
+    [InlineData(typeof(bool), "bool")]
+    [InlineData(typeof(string), "string")]
+    [InlineData(typeof(object), "object")]
+    public void FrameworkTypesRenderAsKeywords(Type type, string expected)
+    {
+        Assert.Equal(expected, Write(TypeDefinition.Get(type)));
+    }
+
+    /// <summary>
+    /// The keywords in the table are all C# 1, so they are safe without a target version.
+    /// <c>nint</c> and <c>nuint</c> are C# 9 and stay out until one reaches rendering - emitting
+    /// them now would break a C# 8 consumer with no way to opt out.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(IntPtr), "IntPtr")]
+    [InlineData(typeof(UIntPtr), "UIntPtr")]
+    public void NativeIntegersKeepTheirFrameworkNames(Type type, string expected)
+    {
+        Assert.Equal(expected, Write(TypeDefinition.Get(type)));
+    }
+
+    /// <summary>
+    /// The table used to be private and keyed on <see cref="Type"/>, which a source generator does
+    /// not have.
+    /// </summary>
+    [Fact]
+    public void TableIsReachableByNamespaceAndName()
+    {
+        Assert.Equal("int", SpecialTypes.GetKeyword("System", "Int32"));
+        Assert.Equal("float", SpecialTypes.GetKeyword("System", "Single"));
+        Assert.Null(SpecialTypes.GetKeyword("System", "Guid"));
+        Assert.Null(SpecialTypes.GetKeyword("Sample", "Widget"));
+
+        Assert.Equal("int", Write(SpecialTypes.Get("System", "Int32")!));
+    }
+
+    /// <summary>
+    /// A keyword needs no qualifying and no using, in any output mode.
+    /// </summary>
+    [Fact]
+    public void KeywordsContributeNoImports()
+    {
+        var context = new OutputContext();
+
+        context.Write(TypeDefinition.Get(typeof(int)));
+        context.GenerateUsingStatements();
+
+        Assert.Equal("int", context.Output());
+    }
+
+    [Fact]
+    public void NullableValueTypesUseTheShorthand()
+    {
+        Assert.Equal("int?", Write(TypeDefinition.Get(typeof(int?))));
+        Assert.Equal("DateTime?", Write(TypeDefinition.Get(typeof(DateTime?))));
+    }
+
+    [Fact]
+    public void NullableValueTypeArraysCompose()
+    {
+        Assert.Equal("int?[]", Write(TypeDefinition.Get(typeof(int?[]))));
+    }
+}

--- a/CSharpAuthor/ArrayTypeDefinition.cs
+++ b/CSharpAuthor/ArrayTypeDefinition.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// An array, as its element type plus a rank.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Array-ness used to be a single <c>bool IsArray</c> carried by the element itself, which can
+/// express <c>string[]</c> and nothing further. <c>MakeArray()</c> on something already an array
+/// returned a copy that was already an array, so <c>string[][]</c> silently came back as
+/// <c>string[]</c>; rank had nowhere to live at all, so <c>int[,]</c> was unreachable.
+/// </para>
+/// <para>
+/// Wrapping instead of flagging makes jagged arrays fall out of nesting - <c>string[][]</c> is an
+/// <see cref="ArrayTypeDefinition"/> whose element is another - and gives rank somewhere to sit.
+/// The element stays unrendered, so an array of a generic still resolves its own namespaces.
+/// </para>
+/// </remarks>
+public class ArrayTypeDefinition : BaseTypeDefinition
+{
+    /// <param name="elementType">What the array holds - itself an array, for a jagged one.</param>
+    /// <param name="rank">
+    /// The number of dimensions. Rank 2 is <c>[,]</c>; a jagged array is rank 1 nested inside
+    /// rank 1, not rank 2.
+    /// </param>
+    public ArrayTypeDefinition(ITypeDefinition elementType, int rank = 1, bool isNullable = false)
+        : base(elementType.TypeDefinitionEnum, elementType.Namespace, elementType.Name, true, isNullable)
+    {
+        if (rank < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rank), rank, "An array has at least one dimension.");
+        }
+
+        ElementType = elementType;
+        Rank = rank;
+    }
+
+    public ITypeDefinition ElementType { get; }
+
+    public int Rank { get; }
+
+    /// <remarks>
+    /// The element's, because that is what actually needs importing - an array introduces no name
+    /// of its own.
+    /// </remarks>
+    public override IEnumerable<string> KnownNamespaces => ElementType.KnownNamespaces;
+
+    /// <remarks>
+    /// Empty. An array is not a constructed generic; the arguments of <c>List&lt;int&gt;[]</c>
+    /// belong to <see cref="ElementType"/>.
+    /// </remarks>
+    public override IReadOnlyList<ITypeDefinition> TypeArguments => Array.Empty<ITypeDefinition>();
+
+    public override void WriteTypeName(StringBuilder builder, TypeOutputMode typeOutputMode = TypeOutputMode.ShortName)
+    {
+        ElementType.WriteTypeName(builder, typeOutputMode);
+
+        builder.Append('[');
+        builder.Append(new string(',', Rank - 1));
+        builder.Append(']');
+
+        if (IsNullable)
+        {
+            builder.Append('?');
+        }
+    }
+
+    public override ITypeDefinition MakeNullable(bool nullable = true)
+    {
+        return new ArrayTypeDefinition(ElementType, Rank, nullable);
+    }
+
+    /// <remarks>
+    /// Wraps rather than flattens, so this is the jagged step: <c>string[]</c> becomes
+    /// <c>string[][]</c> rather than staying <c>string[]</c>.
+    /// </remarks>
+    public override ITypeDefinition MakeArray()
+    {
+        return new ArrayTypeDefinition(this);
+    }
+
+    public override int CompareTo(ITypeDefinition? other)
+    {
+        if (other is not ArrayTypeDefinition arrayType)
+        {
+            return BaseCompareTo(other);
+        }
+
+        if (Rank != arrayType.Rank)
+        {
+            return Rank - arrayType.Rank;
+        }
+
+        if (IsNullable != arrayType.IsNullable)
+        {
+            return IsNullable ? 1 : -1;
+        }
+
+        return ElementType.CompareTo(arrayType.ElementType);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ArrayTypeDefinition arrayType && CompareTo(arrayType) == 0;
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = ElementType.GetHashCode();
+
+            hash = hash * 31 + Rank;
+            hash = hash * 31 + IsNullable.GetHashCode();
+
+            return hash;
+        }
+    }
+
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+
+        WriteTypeName(builder, TypeOutputMode.FullName);
+
+        return builder.ToString();
+    }
+}

--- a/CSharpAuthor/BaseBlockDefinition.cs
+++ b/CSharpAuthor/BaseBlockDefinition.cs
@@ -17,9 +17,34 @@ public abstract class BaseBlockDefinition : BaseOutputComponent
         return component;
     }
 
+    /// <inheritdoc cref="AddStatement{T}"/>
     public virtual object AddIndentedStatement(object component)
     {
         StatementList.Add(new IndentedStatementComponent(CodeOutputComponent.Get( component)));
+
+        return component;
+    }
+
+    /// <summary>
+    /// Adds an expression to this block as a statement - on its own line, indented, and
+    /// terminated with a semicolon.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the difference between <c>Add</c> and running the generated file through a
+    /// compiler. <c>Add</c> places a component exactly as it writes itself, and an expression node
+    /// writes no terminator - so <c>Add(Invoke("writer", "WriteStartObject"))</c> emits
+    /// <c>writer.WriteStartObject()</c> with nothing after it.
+    /// </para>
+    /// <para>
+    /// Returns what it was given, typed, so the component stays usable as an expression after
+    /// being placed. <see cref="AddIndentedStatement"/> is the same thing under an older name that
+    /// takes and returns <see cref="object"/>.
+    /// </para>
+    /// </remarks>
+    public T AddStatement<T>(T component) where T : IOutputComponent
+    {
+        StatementList.Add(new IndentedStatementComponent(component));
 
         return component;
     }
@@ -83,10 +108,13 @@ public abstract class BaseBlockDefinition : BaseOutputComponent
 
         if (value is string stringValue)
         {
-            return "\"" + stringValue + "\"";
+            // A substituted string is a value, so it becomes a literal - unlike the raw code that
+            // CodeOutputComponent.Get makes of one. Quoting goes through QuoteString so the two
+            // places that build a literal escape it the same way.
+            return SyntaxHelpers.QuoteString(stringValue);
         }
 
-        return value.ToString();
+        return value.ToString() ?? "";
     }
 
     public SwitchBlockDefinition Switch(object switchValue)
@@ -110,12 +138,16 @@ public abstract class BaseBlockDefinition : BaseOutputComponent
 
     public void Throw(Type type, params object[] parameters)
     {
-        Add(new PostfixOutputComponent(";\n", new ThrowNewExceptionStatement(TypeDefinition.Get(type), parameters)));
+        Throw(TypeDefinition.Get(type), parameters);
     }
 
     public void Throw(ITypeDefinition exceptionType, params object[] parameters)
     {
-        Add(new PostfixOutputComponent(";\n", new ThrowNewExceptionStatement(exceptionType, parameters)));
+        // Terminated through the same path as every other statement. Appending ";\n" directly
+        // wrote a line break the output context never saw, so Options.NewLine could not apply to
+        // it and a throw was the one statement that ignored the setting.
+        AddIndentedStatement(
+            new ThrowNewExceptionStatement(exceptionType, parameters) { Indented = false });
     }
 
     public void Return(object? returnValue = null)
@@ -144,6 +176,13 @@ public abstract class BaseBlockDefinition : BaseOutputComponent
     public ForEachDefinition ForEach(string variable, IOutputComponent enumerableComponent)
     {
         return Add(new ForEachDefinition(variable, enumerableComponent));
+    }
+
+    /// <inheritdoc cref="ForEachDefinition(ITypeDefinition, string, IOutputComponent)"/>
+    public ForEachDefinition ForEach(
+        ITypeDefinition variableType, string variable, IOutputComponent enumerableComponent)
+    {
+        return Add(new ForEachDefinition(variableType, variable, enumerableComponent));
     }
 
     public IfElseLogicBlockDefinition If(string ifStatement)

--- a/CSharpAuthor/BaseTypeDefinition.cs
+++ b/CSharpAuthor/BaseTypeDefinition.cs
@@ -6,18 +6,68 @@ namespace CSharpAuthor;
 
 public abstract class BaseTypeDefinition : ITypeDefinition
 {
-    protected BaseTypeDefinition(TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable)
+    protected BaseTypeDefinition(TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable, ITypeDefinition? containingType = null)
     {
         Name = name;
         Namespace = ns;
         IsNullable = isNullable;
         IsArray = isArray;
         TypeDefinitionEnum = typeDefinitionEnum;
+        ContainingType = containingType;
     }
 
     public string Name { get; }
 
     public string Namespace { get; }
+
+    /// <summary>
+    /// The type this one is declared inside, for a nested type - <c>Outer</c> for
+    /// <c>Outer.Inner</c>. Null for a top-level type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A nested type used to be indistinguishable from a top-level one, so it wrote its own name
+    /// alone. <c>Inner</c> then bound to whatever <c>Inner</c> happened to be in scope at the point
+    /// of use, or to nothing - and either way the container was gone.
+    /// </para>
+    /// <para>
+    /// Held as a type definition rather than a dotted name so it renders in whatever mode the
+    /// file is in, and so a generic container writes its own type arguments.
+    /// </para>
+    /// </remarks>
+    public ITypeDefinition? ContainingType { get; }
+
+    /// <summary>
+    /// Writes the qualification in front of a type's own name: its container where it has one,
+    /// otherwise whatever prefix the output mode calls for.
+    /// </summary>
+    protected void WriteQualification(StringBuilder builder, TypeOutputMode typeOutputMode)
+    {
+        if (ContainingType != null)
+        {
+            ContainingType.WriteTypeName(builder, typeOutputMode);
+            builder.Append('.');
+
+            return;
+        }
+
+        if (string.IsNullOrEmpty(Namespace))
+        {
+            return;
+        }
+
+        if (typeOutputMode == TypeOutputMode.Global)
+        {
+            builder.Append("global::");
+            builder.Append(Namespace);
+            builder.Append('.');
+        }
+        else if (typeOutputMode == TypeOutputMode.FullName)
+        {
+            builder.Append(Namespace);
+            builder.Append('.');
+        }
+    }
 
     public abstract IEnumerable<string> KnownNamespaces { get; }
 
@@ -34,9 +84,9 @@ public abstract class BaseTypeDefinition : ITypeDefinition
         
     public bool IsArray { get; }
 
-    public abstract int CompareTo(ITypeDefinition other);
+    public abstract int CompareTo(ITypeDefinition? other);
 
-    protected int BaseCompareTo(ITypeDefinition other)
+    protected int BaseCompareTo(ITypeDefinition? other)
     {
         if (ReferenceEquals(null, other))
         {
@@ -72,6 +122,15 @@ public abstract class BaseTypeDefinition : ITypeDefinition
             return IsNullable ? 1 : -1;
         }
 
-        return 0;
+        // Two types named Inner in the same namespace are different types when they are nested in
+        // different containers, so the container is part of identity.
+        var otherContainingType = (other as BaseTypeDefinition)?.ContainingType;
+
+        if (ContainingType == null || otherContainingType == null)
+        {
+            return ContainingType == otherContainingType ? 0 : ContainingType == null ? -1 : 1;
+        }
+
+        return ContainingType.CompareTo(otherContainingType);
     }
 }

--- a/CSharpAuthor/CSharpAuthor.csproj
+++ b/CSharpAuthor/CSharpAuthor.csproj
@@ -14,16 +14,32 @@
 		<RepositoryUrl>https://github.com/ipjohnson/CSharpAuthor</RepositoryUrl>
 	</PropertyGroup>
 
+	<!--
+	  The Roslyn bridge is source-only. Compiling it into this assembly would give every consumer
+	  a Microsoft.CodeAnalysis dependency, including the ones that never touch it; shipping it as
+	  source means a generator project - which already references Roslyn - compiles it with no new
+	  dependency, and everyone else never sees it.
+	-->
+	<ItemGroup>
+		<Compile Remove="Roslyn\**\*.cs" />
+		<None Include="Roslyn\**\*.cs" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<None Remove="Package\CSharpAuthor.*" />
 		<Content Include="Package\CSharpAuthor.*">
 			<Pack>true</Pack>
-			<PackagePath>build\</PackagePath>
+			<PackagePath>build</PackagePath>
 			<PackageCopyToOutput>true</PackageCopyToOutput>
 		</Content>
-		<Content Include="**\*.cs" Exclude="**\obj\**;**\bin\**" Visible="true">
+		<Content Include="**\*.cs" Exclude="**\obj\**;**\bin\**;Roslyn\**" Visible="true">
 			<Pack>true</Pack>
-			<PackagePath>src\CSharpAuthor\</PackagePath>
+			<PackagePath>src\CSharpAuthor</PackagePath>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+		</Content>
+		<Content Include="Roslyn\**\*.cs" Exclude="**\obj\**;**\bin\**" Visible="true">
+			<Pack>true</Pack>
+			<PackagePath>src\CSharpAuthor.Roslyn</PackagePath>
 			<PackageCopyToOutput>true</PackageCopyToOutput>
 		</Content>
 	</ItemGroup>

--- a/CSharpAuthor/ClassDefinition.cs
+++ b/CSharpAuthor/ClassDefinition.cs
@@ -377,11 +377,34 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
         }
     }
 
+    /// <remarks>
+    /// The blank line goes <em>between</em> members rather than before each one. Writing it before
+    /// each put one directly under the opening brace, which is the one place a separator has
+    /// nothing to separate.
+    /// </remarks>
     private void ApplyAllComponents(Action<IOutputComponent> componentAction, IOutputContext outputContext)
     {
+        var bodyStarted = false;
+
+        void WriteSeparatedMember(IOutputComponent component)
+        {
+            if (bodyStarted)
+            {
+                outputContext.WriteLine();
+            }
+
+            bodyStarted = true;
+
+            componentAction(component);
+        }
+
+        // Fields pack together, so they take no separator between themselves - only whatever
+        // follows them is separated from the group.
         foreach (var field in _fields)
         {
             componentAction(field);
+
+            bodyStarted = true;
         }
 
         foreach (var constructor in _constructors)
@@ -392,78 +415,63 @@ public class ClassDefinition : BaseOutputComponent, IConstructContainer, INamedC
                 continue;
             }
 
-            outputContext.WriteLine();
-
-            componentAction(constructor);
+            WriteSeparatedMember(constructor);
         }
-        
+
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _properties,
             method => method.Modifiers.HasFlag(ComponentModifier.Public));
 
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _events,
             e => e.Modifiers.HasFlag(ComponentModifier.Public));
 
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _methods,
             m => m.Modifiers.HasFlag(ComponentModifier.Public));
 
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _properties,
             method => !method.Modifiers.HasFlag(ComponentModifier.Public));
 
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _events,
             e => !e.Modifiers.HasFlag(ComponentModifier.Public));
 
         WriteMemberComponents(
-            componentAction,
-            outputContext,
+            WriteSeparatedMember,
             _methods,
             m => !m.Modifiers.HasFlag(ComponentModifier.Public));
 
         foreach (var classDefinition in _classes)
         {
-            outputContext.WriteLine();
-
-            componentAction(classDefinition);
+            WriteSeparatedMember(classDefinition);
         }
 
         foreach (var outputComponent in _otherComponents)
         {
-            outputContext.WriteLine();
-
-            componentAction(outputComponent);
+            WriteSeparatedMember(outputComponent);
         }
     }
 
-    private void WriteMemberComponents(
-        Action<IOutputComponent> componentAction, 
-        IOutputContext outputContext,
+    private static void WriteMemberComponents(
+        Action<IOutputComponent> writeMember,
         IEnumerable<BaseOutputComponent> components,
         Func<BaseOutputComponent,bool> filter) {
-        
+
         foreach (var component in components)
         {
             if (filter(component))
             {
                 continue;
             }
-            
-            outputContext.WriteLine();
 
-            componentAction(component);
+            writeMember(component);
         }
     }
 

--- a/CSharpAuthor/CodeOutputComponent.cs
+++ b/CSharpAuthor/CodeOutputComponent.cs
@@ -50,7 +50,7 @@ public class CodeOutputComponent : BaseOutputComponent
             return new CodeOutputComponent(booleanValue ? "true" : "false") { Indented = indented };
         }
         
-        return new CodeOutputComponent(value.ToString()) { Indented = indented };
+        return new CodeOutputComponent(value.ToString() ?? "") { Indented = indented };
     }
 
     private static IOutputComponent GetNewStringArray(IEnumerable<string> stringValues, bool indented)

--- a/CSharpAuthor/ConditionalStatement.cs
+++ b/CSharpAuthor/ConditionalStatement.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// The conditional operator, <c>condition ? whenTrue : whenFalse</c>.
+/// </summary>
+/// <remarks>
+/// Parenthesised by default, on the same reasoning as <see cref="LogicStatement"/>: the tree does
+/// not track precedence, so the only choice that is never wrong is to bracket. Set
+/// <see cref="PrintParentheses"/> to false where the position already makes the grouping clear.
+/// </remarks>
+public class ConditionalStatement : BaseOutputComponent
+{
+    private readonly IOutputComponent _condition;
+    private readonly IOutputComponent _whenTrue;
+    private readonly IOutputComponent _whenFalse;
+
+    public ConditionalStatement(object condition, object whenTrue, object whenFalse)
+    {
+        _condition = CodeOutputComponent.Get(condition);
+        _whenTrue = CodeOutputComponent.Get(whenTrue);
+        _whenFalse = CodeOutputComponent.Get(whenFalse);
+
+        // The branches sit inside this operator's own brackets, so their brackets would only
+        // repeat what these already say.
+        LogicStatement.SuppressEnclosedParentheses(_condition);
+    }
+
+    public bool PrintParentheses { get; set; } = true;
+
+    protected override void WriteComponentOutput(IOutputContext outputContext)
+    {
+        if (PrintParentheses)
+        {
+            outputContext.Write("(");
+        }
+
+        _condition.WriteOutput(outputContext);
+        outputContext.Write(" ? ");
+        _whenTrue.WriteOutput(outputContext);
+        outputContext.Write(" : ");
+        _whenFalse.WriteOutput(outputContext);
+
+        if (PrintParentheses)
+        {
+            outputContext.Write(")");
+        }
+    }
+}

--- a/CSharpAuthor/EnumValueDefinition.cs
+++ b/CSharpAuthor/EnumValueDefinition.cs
@@ -32,7 +32,7 @@ public class EnumValueDefinition : BaseOutputComponent
         if (Value != null)
         {
             outputContext.Write(" = ");
-            outputContext.Write(Value.ToString());
+            outputContext.Write(Value.ToString() ?? "");
         }
 
         outputContext.WriteLine(",");

--- a/CSharpAuthor/EquatableArray.cs
+++ b/CSharpAuthor/EquatableArray.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// A read-only sequence that compares by contents, for use in incremental source generator models.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A record compares its collection members by <em>reference</em>: two
+/// <c>record Model(ImmutableArray&lt;Item&gt; Items)</c> holding equal items are not equal. An
+/// incremental generator caches on model equality, so a model carrying an ordinary collection
+/// misses its cache on every keystroke and re-runs the whole pipeline - silently, since the output
+/// is still correct, only slow.
+/// </para>
+/// <para>
+/// Swapping the collection type for this one is the whole fix; nothing else about the model
+/// changes. Every generator written against this library needs it, which is why it ships here
+/// rather than being written again each time.
+/// </para>
+/// <para>
+/// Unconstrained, so that it holds the type this library is mostly used to carry:
+/// <see cref="ITypeDefinition"/> compares by value but implements
+/// <see cref="IComparable{T}"/> rather than <see cref="IEquatable{T}"/>, and a
+/// <c>where T : IEquatable&lt;T&gt;</c> constraint would have shut it out.
+/// Elements compare through <see cref="EqualityComparer{T}.Default"/>, which uses whatever
+/// equality the element actually defines.
+/// </para>
+/// </remarks>
+public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IReadOnlyList<T>
+{
+    private readonly T[]? _items;
+
+    public EquatableArray(params T[]? items)
+    {
+        _items = items;
+    }
+
+    public EquatableArray(IEnumerable<T>? items)
+    {
+        _items = items switch
+        {
+            null => null,
+            T[] array => array,
+            _ => new List<T>(items).ToArray()
+        };
+    }
+
+    public static EquatableArray<T> Empty => new(Array.Empty<T>());
+
+    public int Count => _items?.Length ?? 0;
+
+    public T this[int index] => (_items ?? throw new IndexOutOfRangeException())[index];
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        if (ReferenceEquals(_items, other._items))
+        {
+            return true;
+        }
+
+        if (_items == null || other._items == null || _items.Length != other._items.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _items.Length; i++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(_items[i], other._items[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is EquatableArray<T> other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        if (_items == null)
+        {
+            return 0;
+        }
+
+        unchecked
+        {
+            var hash = 17;
+
+            foreach (var item in _items)
+            {
+                hash = hash * 31 + (item?.GetHashCode() ?? 0);
+            }
+
+            return hash;
+        }
+    }
+
+    public static bool operator ==(EquatableArray<T> left, EquatableArray<T> right) => left.Equals(right);
+
+    public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right) => !left.Equals(right);
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        return ((IEnumerable<T>)(_items ?? Array.Empty<T>())).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public T[] ToArray()
+    {
+        if (_items == null)
+        {
+            return Array.Empty<T>();
+        }
+
+        var copy = new T[_items.Length];
+
+        Array.Copy(_items, copy, _items.Length);
+
+        return copy;
+    }
+}
+
+public static class EquatableArray
+{
+    public static EquatableArray<T> Create<T>(params T[] items) => new(items);
+
+    public static EquatableArray<T> ToEquatableArray<T>(this IEnumerable<T>? items) => new(items);
+}

--- a/CSharpAuthor/ForEachDefinition.cs
+++ b/CSharpAuthor/ForEachDefinition.cs
@@ -7,9 +7,26 @@ namespace CSharpAuthor;
 public class ForEachDefinition : BaseBlockDefinition
 {
     private readonly IOutputComponent _enumerableStatement;
+    private readonly ITypeDefinition? _variableType;
 
     public ForEachDefinition(string instanceName, IOutputComponent enumerableStatement)
+        : this(null, instanceName, enumerableStatement)
     {
+    }
+
+    /// <summary>
+    /// A loop that declares its variable with an explicit type rather than <c>var</c>.
+    /// </summary>
+    /// <remarks>
+    /// The keyword used to be part of the literal <c>"foreach(var "</c>, which made every loop an
+    /// inferred one - so the cast that <c>foreach (Widget w in objects)</c> performs had nowhere to
+    /// be expressed. Passing the type also lets it reach import derivation, which a variable
+    /// declared as <c>var</c> never needed to.
+    /// </remarks>
+    public ForEachDefinition(
+        ITypeDefinition? variableType, string instanceName, IOutputComponent enumerableStatement)
+    {
+        _variableType = variableType;
         _enumerableStatement = enumerableStatement;
         Instance = new InstanceDefinition(instanceName);
     }
@@ -18,12 +35,24 @@ public class ForEachDefinition : BaseBlockDefinition
 
     protected override void WriteComponentOutput(IOutputContext outputContext)
     {
-        outputContext.WriteIndent("foreach(var ");
+        outputContext.WriteIndent("foreach (");
+
+        if (_variableType == null)
+        {
+            outputContext.Write(KeyWords.Var);
+        }
+        else
+        {
+            outputContext.Write(_variableType);
+        }
+
+        outputContext.WriteSpace();
+
         Instance.WriteOutput(outputContext);
         outputContext.Write(" in ");
         _enumerableStatement.WriteOutput(outputContext);
         outputContext.WriteLine(")");
-            
+
         WriteBlock(outputContext);
     }
 }

--- a/CSharpAuthor/GenericTypeDefinition.cs
+++ b/CSharpAuthor/GenericTypeDefinition.cs
@@ -9,6 +9,7 @@ public class GenericTypeDefinition : BaseTypeDefinition
 {
     private int? _hashCode;
     private readonly IReadOnlyList<ITypeDefinition> _closingTypes;
+    private readonly bool _isOpenType;
 
     public GenericTypeDefinition(Type type, IReadOnlyList<ITypeDefinition> closeTypes, bool isArray = false,
         bool isNullable = false) :
@@ -18,12 +19,20 @@ public class GenericTypeDefinition : BaseTypeDefinition
     }
 
     public GenericTypeDefinition(TypeDefinitionEnum classType, string ns, string name, IReadOnlyList<ITypeDefinition> closingTypes,
-        bool isArray = false, bool isNullable = false) : base(classType, ns, name, isArray, isNullable)
+        bool isArray = false, bool isNullable = false, ITypeDefinition? containingType = null)
+        : base(classType, ns, name, isArray, isNullable, containingType)
     {
         _closingTypes = closingTypes;
     }
 
-    public override bool Equals(object obj)
+    private GenericTypeDefinition(TypeDefinitionEnum classType, string ns, string name, IReadOnlyList<ITypeDefinition> closingTypes,
+        bool isArray, bool isNullable, ITypeDefinition? containingType, bool isOpenType)
+        : this(classType, ns, name, closingTypes, isArray, isNullable, containingType)
+    {
+        _isOpenType = isOpenType;
+    }
+
+    public override bool Equals(object? obj)
     {
         if (obj is GenericTypeDefinition genericTypeDefinition)
         {
@@ -46,23 +55,8 @@ public class GenericTypeDefinition : BaseTypeDefinition
         stringBuilder.Append(Namespace);
         stringBuilder.Append('.');
         stringBuilder.Append(Name);
-        stringBuilder.Append('<');
-        var comma = false;
 
-        foreach (var closingType in _closingTypes)
-        {
-            if (comma)
-            {
-                stringBuilder.Append(',');
-            }
-            else
-            {
-                comma = true;
-            }
-            stringBuilder.Append(closingType);
-        }
-
-        stringBuilder.Append('>');
+        WriteTypeArguments(stringBuilder, (b, closingType) => b.Append(closingType));
 
         if (IsArray)
         {
@@ -77,7 +71,7 @@ public class GenericTypeDefinition : BaseTypeDefinition
         return stringBuilder.ToString();
     }
 
-    public override int CompareTo(ITypeDefinition other)
+    public override int CompareTo(ITypeDefinition? other)
     {
         var baseCompare = BaseCompareTo(other);
 
@@ -113,11 +107,16 @@ public class GenericTypeDefinition : BaseTypeDefinition
     {
         get
         {
-            foreach (var typeDefinition in _closingTypes)
+            // An open type writes no arguments, so importing their namespaces would add usings
+            // for names that never appear in the file.
+            if (!_isOpenType)
             {
-                foreach (var knownNamespace in typeDefinition.KnownNamespaces)
+                foreach (var typeDefinition in _closingTypes)
                 {
-                    yield return knownNamespace;
+                    foreach (var knownNamespace in typeDefinition.KnownNamespaces)
+                    {
+                        yield return knownNamespace;
+                    }
                 }
             }
 
@@ -127,42 +126,11 @@ public class GenericTypeDefinition : BaseTypeDefinition
     
     public override void WriteTypeName(StringBuilder builder, TypeOutputMode typeOutputMode = TypeOutputMode.ShortName)
     {
-        if (!string.IsNullOrEmpty(Namespace))
-        {
-            if (typeOutputMode == TypeOutputMode.Global)
-            {
-                builder.Append("global::");
-                builder.Append(Namespace);
-                builder.Append('.');
-
-            }
-            else if (typeOutputMode == TypeOutputMode.FullName)
-            {
-                builder.Append(Namespace);
-                builder.Append('.');
-            }
-        }
+        WriteQualification(builder, typeOutputMode);
 
         builder.Append(Name);
-        builder.Append('<');
 
-        var writeComma = false;
-
-        foreach (var typeDefinition in _closingTypes)
-        {
-            if (writeComma)
-            {
-                builder.Append(',');
-            }
-            else
-            {
-                writeComma = true;
-            }
-
-            typeDefinition.WriteTypeName(builder, typeOutputMode);
-        }
-
-        builder.Append('>');
+        WriteTypeArguments(builder, (b, typeDefinition) => typeDefinition.WriteTypeName(b, typeOutputMode));
 
         if (IsArray)
         {
@@ -177,19 +145,70 @@ public class GenericTypeDefinition : BaseTypeDefinition
 
     public override ITypeDefinition MakeNullable(bool nullable = true)
     {
-        return new GenericTypeDefinition(TypeDefinitionEnum, Namespace, Name, _closingTypes, IsArray, nullable);
+        return new GenericTypeDefinition(TypeDefinitionEnum, Namespace, Name, _closingTypes, IsArray, nullable, ContainingType, _isOpenType);
     }
 
+    /// <inheritdoc cref="ArrayTypeDefinition.MakeArray"/>
     public override ITypeDefinition MakeArray()
     {
-        return new GenericTypeDefinition(TypeDefinitionEnum, Namespace, Name, _closingTypes, true, IsNullable);
+        return new ArrayTypeDefinition(this);
     }
 
+    /// <summary>
+    /// The unbound form of this type - <c>Dictionary&lt;,&gt;</c> for a
+    /// <c>Dictionary&lt;string, int&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// Openness used to be faked by swapping the type arguments for empty ones, which rendered as
+    /// <c>Dictionary&lt;.,.&gt;</c> - each blank argument still wrote the <c>.</c> joining its
+    /// namespace to its name. Recording it instead keeps the arity available and leaves the
+    /// arguments intact for anything that asks.
+    /// </remarks>
     public ITypeDefinition MakeOpenType()
     {
-        var emptyTypes = _closingTypes.Select(_ => TypeDefinition.Get("", "")).ToArray();
+        return new GenericTypeDefinition(
+            TypeDefinitionEnum, Namespace, Name, _closingTypes, IsArray, IsNullable, ContainingType, isOpenType: true);
+    }
 
-        return new GenericTypeDefinition(TypeDefinitionEnum, Namespace, Name, emptyTypes, IsArray, IsNullable);
+    /// <summary>
+    /// Writes <c>&lt;...&gt;</c>, either the argument list or the commas alone when the type is
+    /// open.
+    /// </summary>
+    private void WriteTypeArguments(StringBuilder builder, Action<StringBuilder, ITypeDefinition> writeArgument)
+    {
+        // A generic with no arguments is not generic, and <> is not a type. Writing nothing is
+        // what an empty argument list means.
+        if (_closingTypes.Count == 0)
+        {
+            return;
+        }
+
+        builder.Append('<');
+
+        if (_isOpenType)
+        {
+            builder.Append(new string(',', _closingTypes.Count - 1));
+        }
+        else
+        {
+            var writeSeparator = false;
+
+            foreach (var typeDefinition in _closingTypes)
+            {
+                if (writeSeparator)
+                {
+                    builder.Append(", ");
+                }
+                else
+                {
+                    writeSeparator = true;
+                }
+
+                writeArgument(builder, typeDefinition);
+            }
+        }
+
+        builder.Append('>');
     }
         
     public override IReadOnlyList<ITypeDefinition> TypeArguments => _closingTypes;

--- a/CSharpAuthor/ITypeDefinition.cs
+++ b/CSharpAuthor/ITypeDefinition.cs
@@ -38,4 +38,26 @@ public static class ITypeDefinitionExtensions
 
         return stringBuilder.ToString();
     }
+
+    /// <summary>
+    /// A multidimensional array of this type - <c>int[,]</c> at rank 2.
+    /// </summary>
+    /// <remarks>
+    /// An extension rather than a member of <see cref="ITypeDefinition"/>, so that rank works for
+    /// every implementation without the interface gaining a member each one has to add. Jagged
+    /// arrays need nothing extra: <c>MakeArray().MakeArray()</c> is <c>int[][]</c>.
+    /// </remarks>
+    public static ITypeDefinition MakeArray(this ITypeDefinition typeDefinition, int rank)
+    {
+        return new ArrayTypeDefinition(typeDefinition, rank);
+    }
+
+    /// <summary>
+    /// What an array holds, unwrapping one level - <c>int[]</c> for <c>int[][]</c>. Null when the
+    /// type is not an array.
+    /// </summary>
+    public static ITypeDefinition? GetElementType(this ITypeDefinition typeDefinition)
+    {
+        return typeDefinition is ArrayTypeDefinition arrayType ? arrayType.ElementType : null;
+    }
 }

--- a/CSharpAuthor/IfElseLogicBlockDefinition.cs
+++ b/CSharpAuthor/IfElseLogicBlockDefinition.cs
@@ -15,10 +15,7 @@ public class IfElseLogicBlockDefinition : BaseBlockDefinition
     {
         _ifStatement = ifStatement;
 
-        if (ifStatement is LogicStatement logicStatement)
-        {
-            logicStatement.PrintParentheses = false;
-        }
+        LogicStatement.SuppressEnclosedParentheses(_ifStatement);
     }
 
     public BaseBlockDefinition ElseIf(string ifStatement)
@@ -69,10 +66,7 @@ public class IfElseLogicBlockDefinition : BaseBlockDefinition
         {
             _ifStatement = ifStatement;
 
-            if (_ifStatement is LogicStatement logicStatement)
-            {
-                logicStatement.PrintParentheses = false;
-            }
+            LogicStatement.SuppressEnclosedParentheses(_ifStatement);
         }
 
         protected override void WriteComponentOutput(IOutputContext outputContext)

--- a/CSharpAuthor/IndentedStatementComponent.cs
+++ b/CSharpAuthor/IndentedStatementComponent.cs
@@ -4,6 +4,16 @@ using System.Text;
 
 namespace CSharpAuthor;
 
+/// <summary>
+/// Puts an expression in statement position: on its own line, indented, terminated.
+/// </summary>
+/// <remarks>
+/// Expression nodes write no terminator, because none of them knows whether it is being used as a
+/// statement or as part of one. An <c>Invoke</c> added straight to a block therefore emits
+/// <c>writer.WriteStartObject()</c> with nothing after it, and the generated file does not
+/// compile. This is the wrapper that makes the difference, reached through
+/// <see cref="BaseBlockDefinition.AddStatement{T}"/>.
+/// </remarks>
 public class IndentedStatementComponent : BaseOutputComponent
 {
     private readonly IOutputComponent _component;
@@ -11,6 +21,13 @@ public class IndentedStatementComponent : BaseOutputComponent
     public IndentedStatementComponent(IOutputComponent component)
     {
         _component = component;
+
+        // This wrapper writes the indent, so anything inside it writing its own would indent the
+        // line twice.
+        if (component is BaseOutputComponent baseComponent)
+        {
+            baseComponent.Indented = false;
+        }
     }
 
     protected override void WriteComponentOutput(IOutputContext outputContext)

--- a/CSharpAuthor/KeyWords.cs
+++ b/CSharpAuthor/KeyWords.cs
@@ -43,4 +43,6 @@ public static class KeyWords
     public static string Params => "params";
 
     public static string This => "this";
+
+    public static string Var => "var";
 }

--- a/CSharpAuthor/LogicStatement.cs
+++ b/CSharpAuthor/LogicStatement.cs
@@ -23,6 +23,23 @@ public class LogicStatement : BaseOutputComponent
 
     public bool PrintParentheses { get; set; } = true;
 
+    /// <summary>
+    /// Stops a condition writing the parentheses that the construct enclosing it already writes,
+    /// so <c>if</c>, <c>else if</c> and <c>while</c> produce <c>if (a &amp;&amp; b)</c> rather than
+    /// <c>if ((a &amp;&amp; b))</c>.
+    /// </summary>
+    /// <remarks>
+    /// Only the outermost statement is touched. Nested ones keep their parentheses, because that
+    /// is where they carry precedence rather than repeat it.
+    /// </remarks>
+    internal static void SuppressEnclosedParentheses(IOutputComponent condition)
+    {
+        if (condition is LogicStatement logicStatement)
+        {
+            logicStatement.PrintParentheses = false;
+        }
+    }
+
     protected override void WriteComponentOutput(IOutputContext outputContext)
     {
         if (PrintParentheses)

--- a/CSharpAuthor/NewStatement.cs
+++ b/CSharpAuthor/NewStatement.cs
@@ -43,7 +43,7 @@ public class NewStatement : InstanceDefinition
 
         if (_initValues.Count > 0)
         {
-            outputContext.Write("{ ");
+            outputContext.Write(" { ");
             _initValues.OutputCommaSeparatedList(outputContext, outputContext.Options.BreakInvokeLines);
             outputContext.Write(" }");
         }

--- a/CSharpAuthor/OutputContext.cs
+++ b/CSharpAuthor/OutputContext.cs
@@ -32,6 +32,7 @@ public class OutputContext : IOutputContext
     private readonly HashSet<string> _namespaces = new ();
     private readonly StringBuilder _output;
     private int _indentIndex;
+    private bool _usingStatementsGenerated;
     public OutputContextOptions Options { get; }
 
     public OutputContext(OutputContextOptions? options = null)
@@ -78,9 +79,16 @@ public class OutputContext : IOutputContext
         _output.Append(Options.NewLine);
     }
 
+    /// <remarks>
+    /// <see cref="StringBuilder.AppendLine(string)"/> appends <see cref="Environment.NewLine"/>,
+    /// which is the host's line ending rather than the configured one. That made generated output
+    /// differ by the operating system it was generated on, and left
+    /// <see cref="OutputContextOptions.NewLine"/> reaching almost nothing it claimed to control.
+    /// </remarks>
     public void WriteLine(string text)
     {
-        _output.AppendLine(text);
+        _output.Append(text);
+        _output.Append(Options.NewLine);
     }
 
     public void WriteSpace()
@@ -145,8 +153,20 @@ public class OutputContext : IOutputContext
         }
     }
 
+    /// <remarks>
+    /// Idempotent, because <see cref="CSharpFileDefinition"/> already calls this and nothing says
+    /// so at the call site. Calling it again used to insert the whole block a second time, for a
+    /// file that still compiled and warned CS0105 on every duplicated directive.
+    /// </remarks>
     public void GenerateUsingStatements()
     {
+        if (_usingStatementsGenerated)
+        {
+            return;
+        }
+
+        _usingStatementsGenerated = true;
+
         var namespaceList = _namespaces.ToList();
 
         namespaceList.Sort();
@@ -177,10 +197,12 @@ public class OutputContext : IOutputContext
         }
     }
 
+    /// <inheritdoc cref="WriteLine(string)"/>
     public void WriteIndentedLine(string text)
     {
         _output.Append(IndentString);
-        _output.AppendLine(text);
+        _output.Append(text);
+        _output.Append(Options.NewLine);
     }
 
     private void SetIndentString()

--- a/CSharpAuthor/Package/CSharpAuthor.targets
+++ b/CSharpAuthor/Package/CSharpAuthor.targets
@@ -1,5 +1,18 @@
 <Project>
+  <!--
+    Scoped to src/CSharpAuthor so that the Roslyn bridge, which sits beside it in
+    src/CSharpAuthor.Roslyn, is not pulled in by this glob. It needs Microsoft.CodeAnalysis to
+    compile and has its own property below.
+  -->
   <ItemGroup Condition="'$(PackageCSharpAuthorIncludeSource)' == 'true'">
-    <Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs" Visible="false"/>
+    <Compile Include="$(MSBuildThisFileDirectory)../src/CSharpAuthor/**/*.cs" Visible="false"/>
+  </ItemGroup>
+
+  <!--
+    The Roslyn bridge: ITypeSymbol to ITypeDefinition. Only useful in a project that references
+    Roslyn, which is why it is opt-in separately rather than riding along with the source above.
+  -->
+  <ItemGroup Condition="'$(PackageCSharpAuthorIncludeRoslyn)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)../src/CSharpAuthor.Roslyn/**/*.cs" Visible="false"/>
   </ItemGroup>
 </Project>

--- a/CSharpAuthor/Roslyn/SymbolExtensions.cs
+++ b/CSharpAuthor/Roslyn/SymbolExtensions.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace CSharpAuthor.Roslyn;
+
+/// <summary>
+/// Converts Roslyn symbols into the type model, which is the first thing every source generator
+/// written against this library needs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// There was no such conversion, so every generator wrote one - and every one of them got the same
+/// cases wrong, because the cases are not obvious. A nested type's <c>Name</c> is <c>Inner</c>, so
+/// writing it alone binds to whatever <c>Inner</c> is in scope at the point of use. <c>int?</c>
+/// arrives as <c>Nullable&lt;int&gt;</c>. <c>int[][]</c> is an array of arrays, not an array with a
+/// flag. And the keyword table that turns <c>Int32</c> into <c>int</c> was private and keyed on
+/// <see cref="Type"/>, which a generator does not have.
+/// </para>
+/// <para>
+/// Ships as source in the same package rather than as a second one, gated on
+/// <c>PackageCSharpAuthorIncludeRoslyn</c>. A generator project already references Roslyn, so this
+/// compiles into it with no new dependency.
+/// </para>
+/// </remarks>
+public static class SymbolExtensions
+{
+    /// <summary>
+    /// The type model equivalent of a Roslyn type symbol, rendered lazily like any other - so it
+    /// still picks up short names, <c>global::</c> qualification and import derivation from the
+    /// output context.
+    /// </summary>
+    public static ITypeDefinition GetTypeDefinition(this ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol == null)
+        {
+            throw new ArgumentNullException(nameof(typeSymbol));
+        }
+
+        var typeDefinition = GetUnannotatedTypeDefinition(typeSymbol);
+
+        // A nullable value type is Nullable<T> and is handled with the generics; this is the
+        // reference-type annotation, which carries no wrapper to notice. An unconstrained type
+        // parameter is neither a value type nor a reference type and takes the annotation too.
+        if (typeSymbol.NullableAnnotation == NullableAnnotation.Annotated && !typeSymbol.IsValueType)
+        {
+            return typeDefinition.MakeNullable();
+        }
+
+        return typeDefinition;
+    }
+
+    private static ITypeDefinition GetUnannotatedTypeDefinition(ITypeSymbol typeSymbol)
+    {
+        switch (typeSymbol)
+        {
+            // Element plus rank, recursively - int[][] is an array of int[], and int[,] is one
+            // array of rank 2. A single bool could express neither.
+            case IArrayTypeSymbol arraySymbol:
+                return new ArrayTypeDefinition(
+                    arraySymbol.ElementType.GetTypeDefinition(), arraySymbol.Rank);
+
+            // A type parameter names nothing outside its declaration, so it is never qualified
+            // and contributes no namespace.
+            case ITypeParameterSymbol typeParameterSymbol:
+                return new TypeParameterDefinition(typeParameterSymbol.Name);
+
+            case IDynamicTypeSymbol:
+                return TypeDefinition.Get("", "dynamic");
+
+            case IPointerTypeSymbol pointerSymbol:
+                throw new NotSupportedException(
+                    $"The type model has no pointer type, so {pointerSymbol.ToDisplayString()} cannot be " +
+                    "converted. Write it with SyntaxHelpers rather than converting it, so that the " +
+                    "gap is visible rather than silently producing the pointed-to type.");
+        }
+
+        if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
+        {
+            return TypeDefinition.Get(GetNamespace(typeSymbol), typeSymbol.Name);
+        }
+
+        // int? arrives as Nullable<int>. Treating it as an ordinary generic emits Nullable<int>,
+        // which is correct C# and not what anyone writes.
+        if (namedTypeSymbol.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T &&
+            namedTypeSymbol.TypeArguments.Length == 1)
+        {
+            return namedTypeSymbol.TypeArguments[0].GetTypeDefinition().MakeNullable();
+        }
+
+        var typeNamespace = GetNamespace(namedTypeSymbol);
+
+        var specialType = SpecialTypes.Get(typeNamespace, namedTypeSymbol.Name);
+
+        if (specialType != null)
+        {
+            return specialType;
+        }
+
+        var containingType = namedTypeSymbol.ContainingType?.GetTypeDefinition();
+
+        var definitionEnum = namedTypeSymbol.TypeKind switch
+        {
+            TypeKind.Interface => TypeDefinitionEnum.InterfaceDefinition,
+            TypeKind.Enum => TypeDefinitionEnum.EnumDefinition,
+            _ => TypeDefinitionEnum.ClassDefinition
+        };
+
+        // Arity, not IsGenericType: a type nested in a generic container reports IsGenericType
+        // true while declaring no type parameters of its own, and building a generic from that
+        // renders OuterGeneric<string>.Inner as OuterGeneric<string>.Inner<>. The container
+        // carries the arguments; this type has none.
+        if (namedTypeSymbol.Arity == 0)
+        {
+            return new TypeDefinition(
+                definitionEnum, typeNamespace, namedTypeSymbol.Name, false, false, containingType);
+        }
+
+        var typeArguments = new List<ITypeDefinition>(namedTypeSymbol.TypeArguments.Length);
+
+        foreach (var typeArgument in namedTypeSymbol.TypeArguments)
+        {
+            typeArguments.Add(typeArgument.GetTypeDefinition());
+        }
+
+        var genericDefinition = new GenericTypeDefinition(
+            definitionEnum, typeNamespace, namedTypeSymbol.Name, typeArguments, false, false, containingType);
+
+        // typeof(Dictionary<,>). The arguments are placeholders, so only their number means
+        // anything - which is exactly what an open type keeps.
+        return namedTypeSymbol.IsUnboundGenericType ? genericDefinition.MakeOpenType() : genericDefinition;
+    }
+
+    /// <summary>
+    /// A symbol's namespace, with the global namespace as an empty string rather than the
+    /// <c>&lt;global namespace&gt;</c> that <c>ToDisplayString</c> produces for it.
+    /// </summary>
+    public static string GetNamespace(this ISymbol symbol)
+    {
+        var containingNamespace = symbol?.ContainingNamespace;
+
+        if (containingNamespace == null || containingNamespace.IsGlobalNamespace)
+        {
+            return "";
+        }
+
+        return containingNamespace.ToDisplayString();
+    }
+
+    /// <summary>
+    /// The type a property, field, parameter or method return is declared as.
+    /// </summary>
+    public static ITypeDefinition GetTypeDefinition(this IPropertySymbol propertySymbol)
+    {
+        return propertySymbol.Type.GetTypeDefinition();
+    }
+
+    /// <inheritdoc cref="GetTypeDefinition(IPropertySymbol)"/>
+    public static ITypeDefinition GetTypeDefinition(this IFieldSymbol fieldSymbol)
+    {
+        return fieldSymbol.Type.GetTypeDefinition();
+    }
+
+    /// <inheritdoc cref="GetTypeDefinition(IPropertySymbol)"/>
+    public static ITypeDefinition GetTypeDefinition(this IParameterSymbol parameterSymbol)
+    {
+        return parameterSymbol.Type.GetTypeDefinition();
+    }
+
+    /// <inheritdoc cref="GetTypeDefinition(IPropertySymbol)"/>
+    public static ITypeDefinition GetReturnTypeDefinition(this IMethodSymbol methodSymbol)
+    {
+        return methodSymbol.ReturnType.GetTypeDefinition();
+    }
+}

--- a/CSharpAuthor/SpecialTypes.cs
+++ b/CSharpAuthor/SpecialTypes.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CSharpAuthor;
+
+/// <summary>
+/// The C# keywords for the framework types that have one - <c>int</c> for <c>System.Int32</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This table used to be private and keyed on <see cref="Type"/>, which is precisely what a source
+/// generator does not have: it has an <c>ITypeSymbol</c>, and a namespace and name. So every
+/// generator rewrote the table, and every one of them rewrote its gaps too - <c>float</c>,
+/// <c>char</c>, <c>sbyte</c>, <c>nint</c> and <c>nuint</c> were all missing, which is how
+/// <c>Single</c> and <c>SByte</c> reached generated output.
+/// </para>
+/// <para>
+/// Keyed on namespace and name so it can be reached from either direction, and public because the
+/// first thing written against this library needs it.
+/// </para>
+/// </remarks>
+public static class SpecialTypes
+{
+    /// <remarks>
+    /// Every keyword here is C# 1, so it is safe to emit without knowing what version the
+    /// consumer compiles at. <c>nint</c> and <c>nuint</c> are deliberately absent: they are C# 9,
+    /// and nothing in the output context carries a target version yet, so adding them would emit
+    /// a spelling a C# 8 consumer cannot compile and give them no way to opt out.
+    /// <c>System.IntPtr</c> renders as <c>IntPtr</c>, which is valid everywhere. Add them once
+    /// the target version reaches rendering.
+    /// </remarks>
+    private static readonly Dictionary<string, string> _keywords = new()
+    {
+        { "System.Object", "object" },
+        { "System.String", "string" },
+        { "System.Boolean", "bool" },
+        { "System.Char", "char" },
+        { "System.SByte", "sbyte" },
+        { "System.Byte", "byte" },
+        { "System.Int16", "short" },
+        { "System.UInt16", "ushort" },
+        { "System.Int32", "int" },
+        { "System.UInt32", "uint" },
+        { "System.Int64", "long" },
+        { "System.UInt64", "ulong" },
+        { "System.Single", "float" },
+        { "System.Double", "double" },
+        { "System.Decimal", "decimal" },
+        { "System.Void", "void" },
+    };
+
+    private static readonly Dictionary<string, ITypeDefinition> _definitions = BuildDefinitions();
+
+    private static Dictionary<string, ITypeDefinition> BuildDefinitions()
+    {
+        var definitions = new Dictionary<string, ITypeDefinition>(_keywords.Count);
+
+        foreach (var pair in _keywords)
+        {
+            // No namespace, because a keyword needs no qualifying and no using - which is also
+            // what keeps it out of import derivation in every output mode.
+            definitions.Add(
+                pair.Key,
+                new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", pair.Value, false));
+        }
+
+        return definitions;
+    }
+
+    /// <summary>
+    /// The keyword for a framework type, or null where it has none.
+    /// </summary>
+    public static string? GetKeyword(string? ns, string name)
+    {
+        return _keywords.TryGetValue(QualifiedName(ns, name), out var keyword) ? keyword : null;
+    }
+
+    /// <summary>
+    /// The keyword form of a framework type as a type definition, or null where it has none.
+    /// </summary>
+    public static ITypeDefinition? Get(string? ns, string name)
+    {
+        return _definitions.TryGetValue(QualifiedName(ns, name), out var definition) ? definition : null;
+    }
+
+    /// <inheritdoc cref="Get(string,string)"/>
+    public static ITypeDefinition? Get(Type type)
+    {
+        return type == null ? null : Get(type.Namespace, type.Name);
+    }
+
+    /// <summary>
+    /// Every framework type with a keyword, as full name to keyword.
+    /// </summary>
+    public static IEnumerable<KeyValuePair<string, string>> Keywords => _keywords;
+
+    private static string QualifiedName(string? ns, string name)
+    {
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+}

--- a/CSharpAuthor/SyntaxHelpers.cs
+++ b/CSharpAuthor/SyntaxHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -57,11 +58,35 @@ public static class SyntaxHelpers
         return new PrefixOutputComponent("await ", CodeOutputComponent.Get(outputComponent));
     }
 
+    /// <summary>
+    /// The null-forgiving operator, <c>x!</c> - <em>not</em> logical negation. For <c>!x</c> use
+    /// <see cref="Not"/>.
+    /// </summary>
+    /// <remarks>
+    /// Under <c>#nullable enable</c> both <c>x!</c> and <c>!x</c> are legal wherever a bool is
+    /// expected, so choosing the wrong one produces a condition that compiles and tests the
+    /// opposite thing.
+    /// </remarks>
     public static IOutputComponent Bang(object outputComponent)
     {
         return new PostfixOutputComponent("!", CodeOutputComponent.Get(outputComponent));
     }
 
+    /// <summary>
+    /// Logical negation, <c>!x</c>.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="LogicStatement"/> writes its own parentheses, so negating one yields
+    /// <c>!(a &amp;&amp; b)</c> rather than the <c>!a &amp;&amp; b</c> that would change meaning.
+    /// </remarks>
+    public static IOutputComponent Not(object outputComponent)
+    {
+        return new PrefixOutputComponent("!", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <summary>
+    /// A trailing <c>?</c> - the nullable annotation on a type, not the conditional operator.
+    /// </summary>
     public static IOutputComponent Question(object outputComponent)
     {
         return new PostfixOutputComponent("?", CodeOutputComponent.Get(outputComponent));
@@ -146,13 +171,118 @@ public static class SyntaxHelpers
         return new StaticPropertyStatement(typeDefinition, propertyName) { Indented = false };
     }
 
+    /// <inheritdoc cref="MemberAccess"/>
     public static IOutputComponent Property(IOutputComponent outputComponent, string propertyName)
     {
-        return new LogicStatement(".", outputComponent, propertyName)
+        return MemberAccess(outputComponent, propertyName);
+    }
+
+    /// <summary>
+    /// Reaching a member off something - <c>target.Name</c>, for a property, field or anything
+    /// else named.
+    /// </summary>
+    /// <remarks>
+    /// The same thing <see cref="Property(IOutputComponent,string)"/> has always done, under the
+    /// name that says so. Building it out of a string instead - <c>Code(target + "." + name)</c> -
+    /// costs the target its type reference, and with it the import that reference would have
+    /// derived.
+    /// </remarks>
+    public static IOutputComponent MemberAccess(object target, string memberName)
+    {
+        return new LogicStatement(".", CodeOutputComponent.Get(target), memberName)
         {
-            PrintParentheses = false, 
+            PrintParentheses = false,
             Indented = false
         };
+    }
+
+    /// <summary>
+    /// The null test, <c>x is null</c>.
+    /// </summary>
+    public static IOutputComponent IsNull(object outputComponent)
+    {
+        return new PostfixOutputComponent(" is null", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <summary>
+    /// The negated null test, <c>x is not null</c>. A C# 9 pattern.
+    /// </summary>
+    public static IOutputComponent IsNotNull(object outputComponent)
+    {
+        return new PostfixOutputComponent(" is not null", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <summary>
+    /// A <c>ref</c> argument at a call site. The <c>ref</c> on a parameter <em>declaration</em> is
+    /// <see cref="ParameterModifier"/>.
+    /// </summary>
+    public static IOutputComponent Ref(object outputComponent)
+    {
+        return new PrefixOutputComponent(KeyWords.Ref + " ", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <inheritdoc cref="Ref"/>
+    public static IOutputComponent Out(object outputComponent)
+    {
+        return new PrefixOutputComponent(KeyWords.Out + " ", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <inheritdoc cref="Ref"/>
+    public static IOutputComponent In(object outputComponent)
+    {
+        return new PrefixOutputComponent(KeyWords.In + " ", CodeOutputComponent.Get(outputComponent));
+    }
+
+    /// <summary>
+    /// An <c>out</c> argument that declares its variable - <c>out var name</c>, or
+    /// <c>out Widget name</c> when a type is given.
+    /// </summary>
+    public static IOutputComponent OutVar(string name, ITypeDefinition? variableType = null)
+    {
+        if (variableType == null)
+        {
+            return CodeOutputComponent.Get($"{KeyWords.Out} {KeyWords.Var} {name}");
+        }
+
+        return new CombineOutputComponent(
+            CodeOutputComponent.Get($"{KeyWords.Out} "),
+            new TypeStatement(variableType),
+            CodeOutputComponent.Get(" " + name));
+    }
+
+    /// <summary>
+    /// <c>nameof(x)</c>.
+    /// </summary>
+    public static IOutputComponent NameOf(object outputComponent)
+    {
+        return new WrapStatement(CodeOutputComponent.Get(outputComponent), "nameof(", ")");
+    }
+
+    /// <inheritdoc cref="NameOf(object)"/>
+    public static IOutputComponent NameOf(ITypeDefinition typeDefinition)
+    {
+        return new WrapStatement(new TypeStatement(typeDefinition), "nameof(", ")");
+    }
+
+    /// <summary>
+    /// The conditional operator, <c>condition ? whenTrue : whenFalse</c>.
+    /// </summary>
+    public static ConditionalStatement Conditional(object condition, object whenTrue, object whenFalse)
+    {
+        return new ConditionalStatement(condition, whenTrue, whenFalse) { Indented = false };
+    }
+
+    /// <summary>
+    /// <c>default</c>, or <c>default(T)</c> where a type is given.
+    /// </summary>
+    public static IOutputComponent Default(ITypeDefinition? typeDefinition = null)
+    {
+        if (typeDefinition == null)
+        {
+            return CodeOutputComponent.Get("default");
+        }
+
+        return new WrapStatement(new TypeStatement(typeDefinition), "default(", ")");
     }
 
     public static BaseStatement Base(params object[] parameters)
@@ -169,9 +299,74 @@ public static class SyntaxHelpers
         return new WrapStatement(new ListOutputComponent(statements.ToList()), "this(", ")");
     }
 
-    public static string QuoteString(string stringValue)
+    /// <summary>
+    /// Wraps a value in double quotes as a C# string literal, escaping whatever it contains.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The quotes used to be added without escaping, so a value carrying a <c>"</c>, a backslash
+    /// or a line break closed the literal early and broke the consumer's build. Generators rarely
+    /// see these values - they arrive from attribute arguments and symbol names in user code -
+    /// which made it a bug the generator author could not reproduce.
+    /// </para>
+    /// <para>
+    /// Escaped as a regular literal rather than a verbatim one, because a verbatim literal cannot
+    /// carry a line break without also changing the value.
+    /// </para>
+    /// </remarks>
+    public static string QuoteString(string? stringValue)
     {
-        return "\"" + stringValue + "\"";
+        if (string.IsNullOrEmpty(stringValue))
+        {
+            return "\"\"";
+        }
+
+        var builder = new StringBuilder(stringValue!.Length + 2);
+
+        builder.Append('"');
+
+        foreach (var character in stringValue)
+        {
+            AppendEscaped(builder, character);
+        }
+
+        builder.Append('"');
+
+        return builder.ToString();
+    }
+
+    private static void AppendEscaped(StringBuilder builder, char character)
+    {
+        switch (character)
+        {
+            case '"': builder.Append("\\\""); return;
+            case '\\': builder.Append("\\\\"); return;
+            case '\0': builder.Append("\\0"); return;
+            case '\a': builder.Append("\\a"); return;
+            case '\b': builder.Append("\\b"); return;
+            case '\f': builder.Append("\\f"); return;
+            case '\n': builder.Append("\\n"); return;
+            case '\r': builder.Append("\\r"); return;
+            case '\t': builder.Append("\\t"); return;
+            case '\v': builder.Append("\\v"); return;
+        }
+
+        // The compiler ends a literal at any of these, so they cannot be written through even
+        // though they are neither control characters nor quotes.
+        var isLineTerminator = character is '\u0085' or '\u2028' or '\u2029';
+
+        // Surrogates go out as escapes so a lone one - which has no UTF-8 encoding - still
+        // survives being written to a file. A valid pair escapes to the same pair, so nothing
+        // is lost by not telling them apart.
+        if (isLineTerminator || char.IsControl(character) || char.IsSurrogate(character))
+        {
+            builder.Append("\\u");
+            builder.Append(((int)character).ToString("x4", CultureInfo.InvariantCulture));
+
+            return;
+        }
+
+        builder.Append(character);
     }
 
     public static IOutputComponent Null()

--- a/CSharpAuthor/TypeDefinition.cs
+++ b/CSharpAuthor/TypeDefinition.cs
@@ -9,11 +9,12 @@ public class TypeDefinition : BaseTypeDefinition
 {
     private int? _hashCode;
 
-    public TypeDefinition(TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable = false) : base(typeDefinitionEnum, ns, name,  isArray, isNullable)
+    public TypeDefinition(TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable = false, ITypeDefinition? containingType = null)
+        : base(typeDefinitionEnum, ns, name,  isArray, isNullable, containingType)
     {
-            
+
     }
-        
+
     public override IEnumerable<string> KnownNamespaces
     {
         get { yield return Namespace; }
@@ -21,32 +22,16 @@ public class TypeDefinition : BaseTypeDefinition
 
     public override void WriteTypeName(StringBuilder builder, TypeOutputMode typeOutputMode = TypeOutputMode.ShortName)
     {
-        
         if (Name == "Void" && Namespace == "System")
         {
             builder.Append("void");
             return;
         }
 
-        if (!string.IsNullOrEmpty(Namespace))
-        {
-            if (typeOutputMode == TypeOutputMode.Global)
-            {
-                builder.Append("global::");
-                builder.Append(Namespace);
-                builder.Append('.');
-
-            }
-            else if (typeOutputMode == TypeOutputMode.FullName)
-            {
-                builder.Append(Namespace);
-                builder.Append('.');
-            }
-        }
-
+        WriteQualification(builder, typeOutputMode);
 
         builder.Append(Name);
-        
+
         if (IsArray)
         {
             builder.Append("[]");
@@ -60,22 +45,23 @@ public class TypeDefinition : BaseTypeDefinition
 
     public override ITypeDefinition MakeNullable(bool nullable = true)
     {
-        return new TypeDefinition(TypeDefinitionEnum, Namespace, Name, IsArray, nullable);
+        return new TypeDefinition(TypeDefinitionEnum, Namespace, Name, IsArray, nullable, ContainingType);
     }
 
+    /// <inheritdoc cref="ArrayTypeDefinition.MakeArray"/>
     public override ITypeDefinition MakeArray()
     {
-        return new TypeDefinition(TypeDefinitionEnum, Namespace, Name, true, IsNullable);
+        return new ArrayTypeDefinition(this);
     }
 
     public override IReadOnlyList<ITypeDefinition> TypeArguments => Array.Empty<ITypeDefinition>();
 
-    public override int CompareTo(ITypeDefinition other)
+    public override int CompareTo(ITypeDefinition? other)
     {
         return BaseCompareTo(other);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is TypeDefinition typeDefinition)
         {
@@ -207,6 +193,15 @@ public class TypeDefinition : BaseTypeDefinition
         return new TypeDefinition(definitionEnum, ns, name, isArray, isNullable);
     }
 
+    /// <summary>
+    /// A nested type, written with the container it is declared in.
+    /// </summary>
+    public static TypeDefinition GetNested(ITypeDefinition containingType, string name, TypeDefinitionEnum definitionEnum = TypeDefinitionEnum.ClassDefinition)
+    {
+        return new TypeDefinition(
+            definitionEnum, containingType.Namespace, name, false, false, containingType);
+    }
+
     public static ITypeDefinition Get(Type type)
     {
         if (type == null)
@@ -214,9 +209,27 @@ public class TypeDefinition : BaseTypeDefinition
             throw new ArgumentNullException(nameof(type));
         }
 
-        if (IsKnownType(type, out var knownDefinition))
+        // An array is its element plus a rank, recursively - so int[][] is an array of int[]
+        // rather than an int carrying two flags it has nowhere to put.
+        if (type.IsArray)
         {
-            return knownDefinition!;
+            return new ArrayTypeDefinition(Get(type.GetElementType()!), type.GetArrayRank());
+        }
+
+        // int? arrives as Nullable<int>. Rendering it as a constructed generic is correct C# and
+        // is not what anyone writes.
+        var underlyingType = Nullable.GetUnderlyingType(type);
+
+        if (underlyingType != null)
+        {
+            return Get(underlyingType).MakeNullable();
+        }
+
+        var specialType = SpecialTypes.Get(type);
+
+        if (specialType != null)
+        {
+            return specialType;
         }
 
         var typeDefinition = TypeDefinitionEnum.ClassDefinition;
@@ -229,6 +242,12 @@ public class TypeDefinition : BaseTypeDefinition
         {
             typeDefinition = TypeDefinitionEnum.InterfaceDefinition;
         }
+
+        // A nested type's own Name is just Inner, so without its container it binds to whatever
+        // Inner is in scope where it is used.
+        var containingType = type.IsNested && type.DeclaringType != null
+            ? Get(type.DeclaringType)
+            : null;
 
         if (type.IsConstructedGenericType)
         {
@@ -243,51 +262,11 @@ public class TypeDefinition : BaseTypeDefinition
                 closingTypes.Add(Get(genericArgument));
             }
 
-            return new GenericTypeDefinition(typeDefinition, 
-                genericTypeDefinition.Namespace!, className, closingTypes, type.IsArray);
+            return new GenericTypeDefinition(typeDefinition,
+                genericTypeDefinition.Namespace!, className, closingTypes, false, false, containingType);
         }
 
-        return new TypeDefinition(typeDefinition, type.Namespace!, type.Name, type.IsArray);
+        return new TypeDefinition(typeDefinition, type.Namespace ?? "", type.Name, false, false, containingType);
     }
 
-    private static readonly Dictionary<Type, ITypeDefinition> _knownTypes = new()
-    {
-        { typeof(object), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "object", false) },
-        { typeof(ulong), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "ulong", false) },
-        { typeof(long), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "long", false) },
-        { typeof(uint), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "uint", false) },
-        { typeof(string), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "string", false) },
-        { typeof(int), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "int", false) },
-        { typeof(short), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "short", false) },
-        { typeof(ushort), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "ushort", false) },
-        { typeof(byte), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "byte", false) },
-        { typeof(double), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "double", false) },
-        { typeof(decimal), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "decimal", false) },
-        { typeof(bool), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "bool", false) },
-    };
-    private static readonly Dictionary<Type, ITypeDefinition> _knownArrayTypes = new()
-    {
-        { typeof(object[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "object", true) },
-        { typeof(string[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "string", true) },
-        { typeof(int[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "int", true) },
-        { typeof(uint[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "uint", true) },
-        { typeof(long[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "long", true) },
-        { typeof(ulong[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "ulong", true) },
-        { typeof(short[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "short", true) },
-        { typeof(ushort[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "ushort", true) },
-        { typeof(byte[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "byte", true) },
-        { typeof(bool[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "bool", true) },
-        { typeof(double[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "double", true) },
-        { typeof(decimal[]), new TypeDefinition(TypeDefinitionEnum.ClassDefinition, "", "decimal", true) },
-    };
-
-    private static bool IsKnownType(Type type, out ITypeDefinition? typeDefinition)
-    {
-        if (type.IsArray)
-        {
-            return _knownArrayTypes.TryGetValue(type, out typeDefinition);
-        }
-
-        return _knownTypes.TryGetValue(type, out typeDefinition);
-    }
 }

--- a/CSharpAuthor/TypeParameterDefinition.cs
+++ b/CSharpAuthor/TypeParameterDefinition.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -56,12 +56,13 @@ public class TypeParameterDefinition : ITypeDefinition
         return new TypeParameterDefinition(Name, nullable, IsArray);
     }
 
+    /// <inheritdoc cref="ArrayTypeDefinition.MakeArray"/>
     public ITypeDefinition MakeArray()
     {
-        return new TypeParameterDefinition(Name, IsNullable, true);
+        return new ArrayTypeDefinition(this);
     }
 
-    public int CompareTo(ITypeDefinition other)
+    public int CompareTo(ITypeDefinition? other)
     {
         if (other is not TypeParameterDefinition typeParameter)
         {
@@ -92,7 +93,7 @@ public class TypeParameterDefinition : ITypeDefinition
     /// Value equality, so a model holding one compares equal across runs. A source generator caches
     /// on its models, and reference equality would miss that cache on every edit.
     /// </summary>
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return obj is TypeParameterDefinition other && CompareTo(other) == 0;
     }

--- a/CSharpAuthor/WhileDefinition.cs
+++ b/CSharpAuthor/WhileDefinition.cs
@@ -11,11 +11,13 @@ public class WhileDefinition : BaseBlockDefinition
     public WhileDefinition(object testStatement)
     {
         _testStatement = CodeOutputComponent.Get(testStatement);
+
+        LogicStatement.SuppressEnclosedParentheses(_testStatement);
     }
 
     protected override void WriteComponentOutput(IOutputContext outputContext)
     {
-        outputContext.WriteIndent("while(");
+        outputContext.WriteIndent("while (");
         _testStatement.WriteOutput(outputContext);
         outputContext.WriteLine(")");
 


### PR DESCRIPTION
A source generator was built against this library and its friction recorded. This is the shippable half of what that surfaced. **Every defect here produced C# that compiled** — which is why none of them had been noticed.

Tests: **139 → 263**. A consumer building against the packed `.nupkg` now compiles with zero warnings.

## Type model

| Was | Now |
|---|---|
| `MakeArray().MakeArray()` → `string[]` | `string[][]` |
| `int[,]` unreachable | rank modelled |
| `Outer.Inner` → `Inner` | container carried, in every output mode |
| `int?` → `Nullable<int>` | `int?` |
| keyword table private, keyed on `System.Type` | public, keyed on namespace + name |
| `float`/`char`/`sbyte`/`void` missing | present |
| `MakeOpenType()` → `Dictionary<.,.>` | `Dictionary<,>` |

Arrays became an element type plus a rank instead of a `bool` on the element, which is what let the separate `_knownArrayTypes` table disappear — `Get(typeof(int[][]))` walks element and rank.

## Output correctness

- **`QuoteString` escapes.** A value carrying a quote or line break closed the literal early and broke the consumer's build. Reachable from `[JsonPropertyName]` and symbol names — values the generator author never sees.
- **`Options.NewLine` reaches every line.** `WriteLine`/`WriteIndentedLine` used `StringBuilder.AppendLine`, which appends `Environment.NewLine` — so generated output varied with the OS it was generated on. The repo's own `AssertEqual` normalises CRLF, which is why CI never caught it.
- **`Throw`** terminates through the same path as every other statement rather than appending `";\n"` the context never saw.
- **`GenerateUsingStatements` is idempotent** — `CSharpFileDefinition` already calls it, and a second call re-emitted the whole block.

## Expressions and statements

`Not()` for prefix `!`, beside `Bang()` — which is the postfix null-forgiving operator and was being read as negation. Under `#nullable enable` both compile in a condition, so the compiler will not catch it.

Added the forms that had no node and were being written as raw strings: `IsNull`, `IsNotNull`, `Ref`/`Out`/`In`, `OutVar`, `NameOf`, `Conditional`, `Default`, `MemberAccess`. A raw string carries no `ITypeDefinition`, so each escape also opted its fragment out of import derivation.

`AddStatement<T>` puts an expression in statement position. Without it an `Invoke` added to a block emitted `writer.WriteStartObject()` with no terminator.

## Formatting

`while (`, `foreach (`, `Dictionary<string, int>`, `new Profile() { }`, and no blank line under a type's opening brace. `while` no longer doubles a `LogicStatement`'s parentheses (`if` already suppressed them; `while` did not). `foreach` takes an explicit element type — `var` was baked into the literal, so `foreach (Widget w in items)` could not be expressed.

All of it at the point of emission; no post-processing of output.

## Roslyn bridge

`ITypeSymbol` → `ITypeDefinition` in `CSharpAuthor.Roslyn`, shipped as source in the same package gated on `PackageCSharpAuthorIncludeRoslyn`. **The assembly gains no dependency** — verified against the packed `.nupkg`, whose nuspec lists none.

Tests drive it from real compiled source rather than hand-built symbols, which caught a bug that would otherwise have shipped: Roslyn reports a type nested in a generic container as `IsGenericType` with arity 0, so `OuterGeneric<string>.Inner` rendered as `...Inner<>`. Branching on `Arity` fixes it.

Pointers throw a named exception rather than quietly producing the pointed-to type.

## Packaging

`PackagePath` ended in a separator, producing `build//CSharpAuthor.props`. NuGet auto-imports strictly from `build/CSharpAuthor.props` (NU5129 said so on every pack), so **the targets file was never imported and `PackageCSharpAuthorIncludeSource` did nothing.** The new Roslyn gate would have been dead on arrival.

Nine nullability warnings that only appear when a consumer compiles the source — invisible in this repo's own build, fatal with warnings-as-errors — are fixed.

## Deliberately not here

`nint`/`nuint` are **not** in the keyword table. They are C# 9, and nothing carries a target language version yet, so emitting them would break a C# 8 consumer with no way to opt out. `IntPtr` renders as `IntPtr`, valid everywhere. They go in when profiles land.

Also still open: width-based line breaking and expression-position parentheses (both want the deferred context / precedence tracking), the default property setter (breaking), and the `Global`-mode import leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D66DWkaLTvZqfPa9jq56Jg