### PR TITLE
Cut 2.0.0-preview1002

### DIFF
--- a/CSharpAuthor/CSharpAuthor.csproj
+++ b/CSharpAuthor/CSharpAuthor.csproj
@@ -12,7 +12,7 @@
 			final. A release build overrides both from the tag.
 		-->
 		<VersionPrefix>2.0.0</VersionPrefix>
-		<VersionSuffix>preview1001</VersionSuffix>
+		<VersionSuffix>preview1002</VersionSuffix>
 		<Authors>Ian Johnson</Authors>
 		<PackageTags>source code generation</PackageTags>
 		<PackageProjectUrl>https://github.com/ipjohnson/CSharpAuthor</PackageProjectUrl>


### PR DESCRIPTION
Version bump only — one line in `CSharpAuthor.csproj`.

## What this preview adds over preview1001

Everything from #19: the directives and the modifiers that had no API, closing seven of the adversary suite's catalogued gaps.

- `#region`, `#if`/`#elif`/`#else`/`#endif` and `#line`, as containers rather than pairs of markers. `PragmaOutputComponent` was previously the only directive this library could write.
- `new`, `const` and `file` on `ComponentModifier`, and the C# 14 `field` keyword through `SyntaxHelpers.Field`. `required` already existed as `PropertyDefinition.IsRequired`.

Unit tests 1587 → 1611. Verified packing at `2.0.0-preview1002`.

## For consumers on an older target

`file` is registered `Impossible` rather than lossy. Its nearest downlevel is `internal`, which publishes the type to the whole assembly — so below C# 11 it reports a diagnostic rather than quietly making the type assembly-visible. A consumer that adopts `ComponentModifier.File` while targeting C# 10 will see an error where they might have expected silence. That is the intent.

## ⚠️ This cut has not been through the real oracle

`AGENTS.md` is explicit that the consumer suites are the oracle and the unit tests are not. They did not run for this cut — they fail on the machine that cut it for stale checkout state, **identically against unmodified `main`**, so they say nothing either way.

Worth running `./scripts/run-consumer-tests.sh <checkout> --scope core` against a clean consumer checkout before this preview is relied on.

## Publishing

Merging this does not publish. Pushing the `v2.0.0-preview1002` tag afterwards triggers `release.yaml`, which is the path preview1001 took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D66DWkaLTvZqfPa9jq56Jg