### PR TITLE
Cut 2.0.0-preview1003

### DIFF
--- a/CSharpAuthor/CSharpAuthor.csproj
+++ b/CSharpAuthor/CSharpAuthor.csproj
@@ -12,7 +12,7 @@
 			final. A release build overrides both from the tag.
 		-->
 		<VersionPrefix>2.0.0</VersionPrefix>
-		<VersionSuffix>preview1002</VersionSuffix>
+		<VersionSuffix>preview1003</VersionSuffix>
 		<Authors>Ian Johnson</Authors>
 		<PackageTags>source code generation</PackageTags>
 		<PackageProjectUrl>https://github.com/ipjohnson/CSharpAuthor</PackageProjectUrl>


### PR DESCRIPTION
`VersionSuffix` `preview1002` → `preview1003`.

`2.0.0-preview1002` is already published on nuget.org and its tag points at `859b316`. `main` has moved past it with #21, so today's review follow-ups need a version of their own — re-tagging preview1002 would `--skip-duplicate` on the nuget push and publish nothing.

## Breaking changes since preview1002

- **`AddCode`'s `{argN}` no longer quotes a string.** A string is code in every entry point now, consistent with `AddAttribute`, `Return`, `Throw` and `AddCase`. Callers that relied on the quoting want `SyntaxHelpers.QuoteString`.
- **`EmitProfile.PreferVar` and `EmitProfile.PreferExpressionBodied` are removed**, along with their `.editorconfig` mappings. Both were settable, wired into `Prefers()`, and consulted by zero writers.

## Fixes

- The documented install no longer produces a project that fails to compile: 5,131 warnings / 2 errors → **0 / 0** on a clean netstandard2.0 generator project.
- The migration guide ships in the nupkg; the README's link to it resolves from nuget.org.

Full detail in #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PajKgitj33AnnwMLpttiVG