### PR TITLE
Cut 2.0.0-preview1004

### DIFF
--- a/CSharpAuthor/CSharpAuthor.csproj
+++ b/CSharpAuthor/CSharpAuthor.csproj
@@ -12,7 +12,7 @@
 			final. A release build overrides both from the tag.
 		-->
 		<VersionPrefix>2.0.0</VersionPrefix>
-		<VersionSuffix>preview1003</VersionSuffix>
+		<VersionSuffix>preview1004</VersionSuffix>
 		<Authors>Ian Johnson</Authors>
 		<PackageTags>source code generation</PackageTags>
 		<PackageProjectUrl>https://github.com/ipjohnson/CSharpAuthor</PackageProjectUrl>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ CSharpAuthor ships as **source**, compiled into your project, so a source genera
 without taking on a dependency it would then have to redistribute. In a generator project:
 
 ```xml
-<PackageReference Include="CSharpAuthor" Version="2.0.0-preview1003">
+<PackageReference Include="CSharpAuthor" Version="2.0.0-preview1004">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>build</IncludeAssets>
 </PackageReference>


### PR DESCRIPTION
Version bump for the review follow-ups merged in #23, plus the README's pinned version so the documented install matches what is published.

`release.yaml` publishes from the tag; this PR is the commit the tag will point at.

The workflow's own header says it "has never run" — that comment is stale. preview1001, preview1002 and preview1003 all shipped through it, tag-triggered and successful. Worth correcting separately.

Full contents of the preview are in the commit message.